### PR TITLE
feat: Add SQL linting with reviewdog suggestions

### DIFF
--- a/.github/workflows/database-tests.yml
+++ b/.github/workflows/database-tests.yml
@@ -1,0 +1,51 @@
+name: Database Schema Tests
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'database/**'
+      - 'docker-compose.yml'
+      - 'test-databases.sh'
+      - '.github/workflows/database-tests.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'database/**'
+      - 'docker-compose.yml'
+      - 'test-databases.sh'
+      - '.github/workflows/database-tests.yml'
+
+jobs:
+  test:
+    name: Test Database Schemas
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run Database Tests
+        run: |
+          docker compose up --build --abort-on-container-exit
+        env:
+          COMPOSE_DOCKER_CLI_BUILD: 1
+          DOCKER_BUILDKIT: 1
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker compose down -v
+          docker system prune -f
+
+      - name: Check Test Results
+        run: |
+          # Check if the test container exited with success
+          EXIT_CODE=$(docker compose ps -a --format "{{.ExitCode}}" test)
+          if [ "$EXIT_CODE" != "0" ]; then
+            echo "Database tests failed with exit code $EXIT_CODE"
+            exit 1
+          fi 

--- a/.github/workflows/sql-lint.yml
+++ b/.github/workflows/sql-lint.yml
@@ -1,0 +1,40 @@
+name: SQL Linting
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'database/sql/**'
+      - '.sqlfluff'
+  pull_request:
+    paths:
+      - 'database/sql/**'
+      - '.sqlfluff'
+
+jobs:
+  sql-lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+          
+      - name: Install SQLFluff
+        run: pip install sqlfluff==2.3.5
+        
+      - name: Run SQLFluff fix
+        run: sqlfluff fix database/sql --force
+        
+      - uses: reviewdog/action-suggester@v1
+        with:
+          tool_name: sqlfluff
+          fail_on_error: false

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,0 +1,36 @@
+[sqlfluff]
+dialect = postgres
+templater = jinja
+
+# Indentation
+[sqlfluff:indentation]
+tab_space_size = 4
+indent_unit = space
+
+# Rules configuration
+[sqlfluff:rules]
+max_line_length = 88
+tab_space_size = 4
+allow_scalar = True
+single_table_references = consistent
+unquoted_identifiers_policy = all
+
+# L010: Keywords should be consistently capitalized
+[sqlfluff:rules:L010]
+capitalisation_policy = upper
+
+# L011: Implicit/explicit aliasing of tables
+[sqlfluff:rules:L011]
+aliasing = explicit
+
+# L014: Unquoted identifiers
+[sqlfluff:rules:L014]
+extended_capitalisation_policy = lower
+
+# L029: Keywords should not be used as identifiers
+[sqlfluff:rules:L029]
+unquoted_identifiers_policy = all
+
+# L030: Function names
+[sqlfluff:rules:L030]
+extended_capitalisation_policy = upper 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Lamp Control API Reference Implementation
+# Lamp Control API Reference
+
+[![Database Schema Tests](https://github.com/davideme/lamp-control-api-reference/actions/workflows/database-tests.yml/badge.svg)](https://github.com/davideme/lamp-control-api-reference/actions/workflows/database-tests.yml)
 
 A comprehensive reference implementation of a simple lamp control API in multiple popular web programming languages, showcasing different API styles (REST, GraphQL, and gRPC) and database technologies.
 

--- a/database/ANALYTICS.md
+++ b/database/ANALYTICS.md
@@ -1,0 +1,203 @@
+# Analytics Guide
+
+This document outlines the analytics capabilities built into the lamp control database schema and provides guidance on tracking key metrics.
+
+## Key Metrics
+
+### Operational Metrics
+
+1. **Lamp State Changes**
+   ```sql
+   -- MySQL/PostgreSQL
+   SELECT 
+     DATE_TRUNC('hour', updated_at) as hour,
+     COUNT(*) as total_changes
+   FROM lamps
+   WHERE deleted_at IS NULL
+   GROUP BY DATE_TRUNC('hour', updated_at)
+   ORDER BY hour;
+
+   -- MongoDB
+   db.lamps.aggregate([
+     { $match: { deletedAt: null } },
+     { $group: {
+         _id: { $dateTrunc: { date: "$updatedAt", unit: "hour" } },
+         total_changes: { $count: {} }
+     }},
+     { $sort: { "_id": 1 } }
+   ])
+   ```
+
+2. **Active Lamps**
+   ```sql
+   -- MySQL/PostgreSQL
+   SELECT 
+     COUNT(*) as total_lamps,
+     SUM(CASE WHEN is_on THEN 1 ELSE 0 END) as lamps_on,
+     SUM(CASE WHEN NOT is_on THEN 1 ELSE 0 END) as lamps_off
+   FROM lamps
+   WHERE deleted_at IS NULL;
+
+   -- MongoDB
+   db.lamps.aggregate([
+     { $match: { deletedAt: null } },
+     { $group: {
+         _id: null,
+         total_lamps: { $count: {} },
+         lamps_on: { $sum: { $cond: ["$isOn", 1, 0] } },
+         lamps_off: { $sum: { $cond: ["$isOn", 0, 1] } }
+     }}
+   ])
+   ```
+
+### Time-Based Analysis
+
+1. **Usage Patterns**
+   ```sql
+   -- MySQL/PostgreSQL
+   SELECT 
+     EXTRACT(HOUR FROM updated_at) as hour_of_day,
+     COUNT(*) as changes,
+     SUM(CASE WHEN is_on THEN 1 ELSE 0 END) as turned_on,
+     SUM(CASE WHEN NOT is_on THEN 1 ELSE 0 END) as turned_off
+   FROM lamps
+   WHERE deleted_at IS NULL
+   GROUP BY EXTRACT(HOUR FROM updated_at)
+   ORDER BY hour_of_day;
+
+   -- MongoDB
+   db.lamps.aggregate([
+     { $match: { deletedAt: null } },
+     { $group: {
+         _id: { $hour: "$updatedAt" },
+         changes: { $count: {} },
+         turned_on: { $sum: { $cond: ["$isOn", 1, 0] } },
+         turned_off: { $sum: { $cond: ["$isOn", 0, 1] } }
+     }},
+     { $sort: { "_id": 1 } }
+   ])
+   ```
+
+2. **Lifetime Analysis**
+   ```sql
+   -- MySQL/PostgreSQL
+   SELECT 
+     id,
+     created_at,
+     COALESCE(deleted_at, CURRENT_TIMESTAMP) as end_time,
+     EXTRACT(EPOCH FROM COALESCE(deleted_at, CURRENT_TIMESTAMP) - created_at)/86400 as days_active
+   FROM lamps
+   ORDER BY days_active DESC;
+
+   -- MongoDB
+   db.lamps.aggregate([
+     { $project: {
+         created: "$createdAt",
+         end: { $ifNull: ["$deletedAt", new Date()] },
+         days_active: {
+           $divide: [
+             { $subtract: [
+               { $ifNull: ["$deletedAt", new Date()] },
+               "$createdAt"
+             ]},
+             86400000  // milliseconds in a day
+           ]
+         }
+     }},
+     { $sort: { days_active: -1 } }
+   ])
+   ```
+
+## Performance Optimization
+
+### Indexing Strategy
+The schema includes indexes optimized for analytics queries:
+- Status index for quick state aggregations
+- Timestamp indexes for time-based analysis
+- Soft delete index for active lamp queries
+
+### Query Optimization Tips
+1. Use timestamp range queries with indexes
+2. Leverage boolean operations for status queries
+3. Consider materialized views for complex aggregations
+4. Use appropriate date/time functions for temporal analysis
+
+## Data Export
+
+### CSV Export
+```sql
+-- MySQL
+SELECT * FROM lamps
+INTO OUTFILE '/tmp/lamps_export.csv'
+FIELDS TERMINATED BY ','
+ENCLOSED BY '"'
+LINES TERMINATED BY '\n';
+
+-- PostgreSQL
+COPY lamps TO '/tmp/lamps_export.csv' WITH CSV HEADER;
+
+-- MongoDB
+mongoexport --db lamp_control --collection lamps --type=csv --out=/tmp/lamps_export.csv --fields="_id,isOn,createdAt,updatedAt,deletedAt"
+```
+
+### JSON Export
+```bash
+# MongoDB
+mongoexport --db lamp_control --collection lamps --out=/tmp/lamps_export.json
+
+# PostgreSQL (requires JSON functions)
+psql -d lamp_control -c "COPY (SELECT row_to_json(lamps) FROM lamps) TO '/tmp/lamps_export.json'"
+```
+
+## Monitoring Recommendations
+
+1. **Key Metrics to Monitor**
+   - Query response times
+   - Index usage statistics
+   - Storage growth rate
+   - Update frequency
+
+2. **Alerting Thresholds**
+   - High query latency (> 100ms)
+   - Low index usage (< 90%)
+   - Rapid storage growth
+   - Unusual update patterns
+
+## Integration with Analytics Tools
+
+### Time Series Data
+The schema supports time series analysis through:
+- Timestamp fields (created_at, updated_at)
+- Status change tracking
+- Soft delete support
+
+### ETL Considerations
+1. Use timestamp fields for incremental loads
+2. Track changes through updated_at field
+3. Handle soft deletes appropriately
+4. Consider partitioning by time ranges
+
+### Recommended Tools
+1. **Visualization**
+   - Grafana
+   - Tableau
+   - Power BI
+
+2. **Analysis**
+   - Python (pandas)
+   - R
+   - Apache Spark
+
+## Future Enhancements
+
+1. **Planned Features**
+   - Partitioning for historical data
+   - Materialized views for common aggregations
+   - Additional performance metrics
+   - Enhanced time series capabilities
+
+2. **Scalability Considerations**
+   - Sharding strategies
+   - Archive policies
+   - Aggregation optimization
+   - Cache implementation 

--- a/database/README.md
+++ b/database/README.md
@@ -1,0 +1,169 @@
+# Database Setup Guide
+
+This guide provides instructions for setting up the database for the Lamp Control API. The system supports both SQL (MySQL/PostgreSQL) and MongoDB implementations.
+
+## Table of Contents
+
+- [Common Features](#common-features)
+- [MySQL Setup](#mysql-setup)
+- [PostgreSQL Setup](#postgresql-setup)
+- [MongoDB Setup](#mongodb-setup)
+
+## Common Features
+
+All database implementations share these common features:
+
+- UUID-based primary keys
+- Timestamps (created_at, updated_at)
+- Soft delete support (deleted_at)
+- Status tracking (ON/OFF)
+- Indexed fields for optimal query performance
+
+## MySQL Setup
+
+1. Install MySQL (8.0 or later recommended)
+
+2. Create the database and tables:
+   ```bash
+   mysql -u your_user -p < database/sql/mysql/schema.sql
+   ```
+
+3. Verify the setup:
+   ```sql
+   USE lamp_control;
+   SHOW TABLES;
+   DESCRIBE lamps;
+   ```
+
+### Key Features
+- Uses `CHAR(36)` for UUID storage
+- Automatic UUID generation via trigger
+- ENUM type for status field
+- Automatic timestamp management
+- InnoDB engine for ACID compliance
+
+## PostgreSQL Setup
+
+1. Install PostgreSQL (13.0 or later recommended)
+
+2. Create a new database:
+   ```bash
+   createdb lamp_control
+   ```
+
+3. Apply the schema:
+   ```bash
+   psql -d lamp_control -f database/sql/postgresql/schema.sql
+   ```
+
+4. Verify the setup:
+   ```sql
+   \dt
+   \d lamps
+   ```
+
+### Key Features
+- Native UUID type support
+- Custom ENUM type for status
+- Automatic timestamp management via trigger
+- Full timezone support
+- Rich indexing capabilities
+
+## MongoDB Setup
+
+1. Install MongoDB (5.0 or later recommended)
+
+2. Create the database and collection:
+   ```javascript
+   use lamp_control
+   
+   // Copy and paste the collection creation script from database/mongodb/schema.md
+   ```
+
+3. Verify the setup:
+   ```javascript
+   db.lamps.getIndexes()
+   ```
+
+### Key Features
+- Schema validation using JSON Schema
+- Flexible document structure
+- Native date type support
+- Automatic indexing of _id field
+- Rich query capabilities
+
+## Development Guidelines
+
+1. **Schema Changes**
+   - Document all schema changes
+   - Provide migration scripts
+   - Update all language implementations
+
+2. **Data Integrity**
+   - Always use UUIDs for IDs
+   - Maintain consistent timestamp formats
+   - Implement proper soft delete handling
+
+3. **Performance**
+   - Use appropriate indexes
+   - Monitor query performance
+   - Optimize for common operations
+
+4. **Testing**
+   - Test with representative data volumes
+   - Verify index effectiveness
+   - Ensure proper error handling
+
+## Troubleshooting
+
+### Common Issues
+
+1. **MySQL**
+   - Character set issues: Ensure utf8mb4 is used
+   - UUID generation: Verify trigger installation
+
+2. **PostgreSQL**
+   - Extension availability: Check uuid-ossp
+   - Enum type creation: Verify type exists
+
+3. **MongoDB**
+   - Validation errors: Check document structure
+   - Index creation: Verify index build completion
+
+### Support
+
+For issues or questions:
+1. Check the troubleshooting guide
+2. Review the schema documentation
+3. Open an issue in the repository
+
+## Migration Guide
+
+When migrating between database systems:
+
+1. Export data in a consistent format
+2. Verify UUID compatibility
+3. Check timestamp formats
+4. Validate status values
+5. Verify index creation
+
+## Security Considerations
+
+1. **Access Control**
+   - Use dedicated service accounts
+   - Implement least privilege access
+   - Regularly rotate credentials
+
+2. **Data Protection**
+   - Enable TLS for connections
+   - Implement backup strategies
+   - Monitor access patterns
+
+## Performance Monitoring
+
+Monitor these key metrics:
+1. Query response times
+2. Index usage statistics
+3. Connection pool usage
+4. Storage utilization
+5. Cache hit rates 

--- a/database/mongodb/init.js
+++ b/database/mongodb/init.js
@@ -1,0 +1,48 @@
+// MongoDB initialization script
+db = db.getSiblingDB('lamp_control');
+
+// Create collection with schema validation
+db.createCollection("lamps", {
+  validator: {
+    $jsonSchema: {
+      bsonType: "object",
+      required: ["_id", "isOn", "createdAt", "updatedAt"],
+      properties: {
+        _id: {
+          bsonType: "string",
+          description: "UUID string as the document identifier"
+        },
+        isOn: {
+          bsonType: "bool",
+          description: "Current status of the lamp (true = ON, false = OFF)"
+        },
+        createdAt: {
+          bsonType: "date",
+          description: "Timestamp when the lamp was created"
+        },
+        updatedAt: {
+          bsonType: "date",
+          description: "Timestamp when the lamp was last updated"
+        },
+        deletedAt: {
+          bsonType: ["date", "null"],
+          description: "Timestamp when the lamp was soft deleted"
+        }
+      }
+    }
+  }
+});
+
+// Create indexes
+db.lamps.createIndex({ "isOn": 1 });
+db.lamps.createIndex({ "createdAt": 1 });
+db.lamps.createIndex({ "deletedAt": 1 });
+
+// Insert a test document
+db.lamps.insertOne({
+  _id: UUID().toString(),
+  isOn: false,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  deletedAt: null
+}); 

--- a/database/mongodb/schema.md
+++ b/database/mongodb/schema.md
@@ -1,0 +1,147 @@
+# MongoDB Schema Documentation
+
+## Database: lamp_control
+
+### Collection: lamps
+
+#### Document Structure
+
+```javascript
+{
+  "_id": "<UUID string>",  // Unique identifier for the lamp
+  "status": "OFF",         // Current status of the lamp (enum: "ON" or "OFF")
+  "createdAt": ISODate(),  // Timestamp when the lamp was created
+  "updatedAt": ISODate(),  // Timestamp when the lamp was last updated
+  "deletedAt": ISODate()   // Timestamp when the lamp was soft deleted (null if active)
+}
+```
+
+#### Validation Schema
+
+```javascript
+{
+  $jsonSchema: {
+    bsonType: "object",
+    required: ["_id", "status", "createdAt", "updatedAt"],
+    properties: {
+      _id: {
+        bsonType: "string",
+        description: "UUID string as the document identifier"
+      },
+      status: {
+        enum: ["ON", "OFF"],
+        description: "Current status of the lamp"
+      },
+      createdAt: {
+        bsonType: "date",
+        description: "Timestamp when the lamp was created"
+      },
+      updatedAt: {
+        bsonType: "date",
+        description: "Timestamp when the lamp was last updated"
+      },
+      deletedAt: {
+        bsonType: ["date", "null"],
+        description: "Timestamp when the lamp was soft deleted"
+      }
+    }
+  }
+}
+```
+
+#### Indexes
+
+1. Default `_id` index (automatically created)
+```javascript
+db.lamps.createIndex({ "_id": 1 }, { unique: true })
+```
+
+2. Status index for quick status-based queries
+```javascript
+db.lamps.createIndex({ "status": 1 })
+```
+
+3. Timestamps indexes for time-based queries and soft deletes
+```javascript
+db.lamps.createIndex({ "createdAt": 1 })
+db.lamps.createIndex({ "deletedAt": 1 })
+```
+
+#### Example Usage
+
+1. Create a new lamp
+```javascript
+db.lamps.insertOne({
+  "_id": uuid(),  // Generate UUID
+  "status": "OFF",
+  "createdAt": new Date(),
+  "updatedAt": new Date(),
+  "deletedAt": null
+})
+```
+
+2. Update lamp status
+```javascript
+db.lamps.updateOne(
+  { "_id": "<lamp_id>" },
+  { 
+    $set: { 
+      "status": "ON",
+      "updatedAt": new Date()
+    }
+  }
+)
+```
+
+3. Soft delete a lamp
+```javascript
+db.lamps.updateOne(
+  { "_id": "<lamp_id>" },
+  { 
+    $set: { 
+      "deletedAt": new Date(),
+      "updatedAt": new Date()
+    }
+  }
+)
+```
+
+4. Query active lamps
+```javascript
+db.lamps.find({ "deletedAt": null })
+```
+
+### Collection Creation Script
+
+```javascript
+db.createCollection("lamps", {
+  validator: {
+    $jsonSchema: {
+      bsonType: "object",
+      required: ["_id", "status", "createdAt", "updatedAt"],
+      properties: {
+        _id: {
+          bsonType: "string",
+          description: "UUID string as the document identifier"
+        },
+        status: {
+          enum: ["ON", "OFF"],
+          description: "Current status of the lamp"
+        },
+        createdAt: {
+          bsonType: "date",
+          description: "Timestamp when the lamp was created"
+        },
+        updatedAt: {
+          bsonType: "date",
+          description: "Timestamp when the lamp was last updated"
+        },
+        deletedAt: {
+          bsonType: ["date", "null"],
+          description: "Timestamp when the lamp was soft deleted"
+        }
+      }
+    }
+  }
+})
+``` 

--- a/database/mongodb/schema.md
+++ b/database/mongodb/schema.md
@@ -9,7 +9,7 @@
 ```javascript
 {
   "_id": "<UUID string>",  // Unique identifier for the lamp
-  "status": "OFF",         // Current status of the lamp (enum: "ON" or "OFF")
+  "isOn": false,          // Current status of the lamp (true = ON, false = OFF)
   "createdAt": ISODate(),  // Timestamp when the lamp was created
   "updatedAt": ISODate(),  // Timestamp when the lamp was last updated
   "deletedAt": ISODate()   // Timestamp when the lamp was soft deleted (null if active)
@@ -22,15 +22,15 @@
 {
   $jsonSchema: {
     bsonType: "object",
-    required: ["_id", "status", "createdAt", "updatedAt"],
+    required: ["_id", "isOn", "createdAt", "updatedAt"],
     properties: {
       _id: {
         bsonType: "string",
         description: "UUID string as the document identifier"
       },
-      status: {
-        enum: ["ON", "OFF"],
-        description: "Current status of the lamp"
+      isOn: {
+        bsonType: "bool",
+        description: "Current status of the lamp (true = ON, false = OFF)"
       },
       createdAt: {
         bsonType: "date",
@@ -58,7 +58,7 @@ db.lamps.createIndex({ "_id": 1 }, { unique: true })
 
 2. Status index for quick status-based queries
 ```javascript
-db.lamps.createIndex({ "status": 1 })
+db.lamps.createIndex({ "isOn": 1 })
 ```
 
 3. Timestamps indexes for time-based queries and soft deletes
@@ -73,7 +73,7 @@ db.lamps.createIndex({ "deletedAt": 1 })
 ```javascript
 db.lamps.insertOne({
   "_id": uuid(),  // Generate UUID
-  "status": "OFF",
+  "isOn": false,
   "createdAt": new Date(),
   "updatedAt": new Date(),
   "deletedAt": null
@@ -86,7 +86,7 @@ db.lamps.updateOne(
   { "_id": "<lamp_id>" },
   { 
     $set: { 
-      "status": "ON",
+      "isOn": true,
       "updatedAt": new Date()
     }
   }
@@ -118,15 +118,15 @@ db.createCollection("lamps", {
   validator: {
     $jsonSchema: {
       bsonType: "object",
-      required: ["_id", "status", "createdAt", "updatedAt"],
+      required: ["_id", "isOn", "createdAt", "updatedAt"],
       properties: {
         _id: {
           bsonType: "string",
           description: "UUID string as the document identifier"
         },
-        status: {
-          enum: ["ON", "OFF"],
-          description: "Current status of the lamp"
+        isOn: {
+          bsonType: "bool",
+          description: "Current status of the lamp (true = ON, false = OFF)"
         },
         createdAt: {
           bsonType: "date",

--- a/database/sql/mysql/schema.sql
+++ b/database/sql/mysql/schema.sql
@@ -16,11 +16,11 @@ USE lamp_control;
 -- Lamps table
 CREATE TABLE IF NOT EXISTS lamps (
     id CHAR(36) PRIMARY KEY,  -- UUID format
-    status ENUM('ON', 'OFF') NOT NULL DEFAULT 'OFF',
+    is_on BOOLEAN NOT NULL DEFAULT FALSE,  -- true = ON, false = OFF
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     deleted_at TIMESTAMP NULL DEFAULT NULL,  -- For soft deletes
-    INDEX idx_status (status),
+    INDEX idx_is_on (is_on),
     INDEX idx_created_at (created_at),
     INDEX idx_deleted_at (deleted_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/database/sql/mysql/schema.sql
+++ b/database/sql/mysql/schema.sql
@@ -1,0 +1,41 @@
+-- MySQL Schema for Lamp Control API
+-- Version: 1.0.0
+
+-- Enable strict mode and UTF-8 encoding
+SET sql_mode = 'STRICT_ALL_TABLES';
+SET NAMES utf8mb4;
+SET character_set_client = utf8mb4;
+
+-- Create database if it doesn't exist
+CREATE DATABASE IF NOT EXISTS lamp_control
+    CHARACTER SET = utf8mb4
+    COLLATE = utf8mb4_unicode_ci;
+
+USE lamp_control;
+
+-- Lamps table
+CREATE TABLE IF NOT EXISTS lamps (
+    id CHAR(36) PRIMARY KEY,  -- UUID format
+    status ENUM('ON', 'OFF') NOT NULL DEFAULT 'OFF',
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP NULL DEFAULT NULL,  -- For soft deletes
+    INDEX idx_status (status),
+    INDEX idx_created_at (created_at),
+    INDEX idx_deleted_at (deleted_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Add table comment
+ALTER TABLE lamps COMMENT 'Stores lamp entities and their current status';
+
+-- Create trigger for UUID generation if not provided
+DELIMITER //
+CREATE TRIGGER before_insert_lamps
+BEFORE INSERT ON lamps
+FOR EACH ROW
+BEGIN
+    IF NEW.id IS NULL THEN
+        SET NEW.id = UUID();
+    END IF;
+END//
+DELIMITER ; 

--- a/database/sql/postgresql/schema.sql
+++ b/database/sql/postgresql/schema.sql
@@ -13,18 +13,10 @@
 -- Enable UUID extension
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
--- Create custom types
-DO $$ 
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'lamp_status') THEN
-        CREATE TYPE lamp_status AS ENUM ('ON', 'OFF');
-    END IF;
-END $$;
-
 -- Lamps table
 CREATE TABLE IF NOT EXISTS lamps (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    status lamp_status NOT NULL DEFAULT 'OFF',
+    is_on BOOLEAN NOT NULL DEFAULT FALSE,  -- true = ON, false = OFF
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
     deleted_at TIMESTAMP WITH TIME ZONE
@@ -33,13 +25,13 @@ CREATE TABLE IF NOT EXISTS lamps (
 -- Add table comment
 COMMENT ON TABLE lamps IS 'Stores lamp entities and their current status';
 COMMENT ON COLUMN lamps.id IS 'Unique identifier for the lamp';
-COMMENT ON COLUMN lamps.status IS 'Current status of the lamp (ON/OFF)';
+COMMENT ON COLUMN lamps.is_on IS 'Current status of the lamp (true = ON, false = OFF)';
 COMMENT ON COLUMN lamps.created_at IS 'Timestamp when the lamp was created';
 COMMENT ON COLUMN lamps.updated_at IS 'Timestamp when the lamp was last updated';
 COMMENT ON COLUMN lamps.deleted_at IS 'Timestamp when the lamp was soft deleted, NULL if active';
 
 -- Create indexes
-CREATE INDEX IF NOT EXISTS idx_lamps_status ON lamps (status);
+CREATE INDEX IF NOT EXISTS idx_lamps_is_on ON lamps (is_on);
 CREATE INDEX IF NOT EXISTS idx_lamps_created_at ON lamps (created_at);
 CREATE INDEX IF NOT EXISTS idx_lamps_deleted_at ON lamps (deleted_at);
 

--- a/database/sql/postgresql/schema.sql
+++ b/database/sql/postgresql/schema.sql
@@ -1,0 +1,58 @@
+-- PostgreSQL Schema for Lamp Control API
+-- Version: 1.0.0
+
+-- Create database if connecting as superuser
+-- DO $$ 
+-- BEGIN
+--     CREATE DATABASE lamp_control;
+-- EXCEPTION
+--     WHEN duplicate_database THEN
+--         NULL;
+-- END $$;
+
+-- Enable UUID extension
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- Create custom types
+DO $$ 
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'lamp_status') THEN
+        CREATE TYPE lamp_status AS ENUM ('ON', 'OFF');
+    END IF;
+END $$;
+
+-- Lamps table
+CREATE TABLE IF NOT EXISTS lamps (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    status lamp_status NOT NULL DEFAULT 'OFF',
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP WITH TIME ZONE
+);
+
+-- Add table comment
+COMMENT ON TABLE lamps IS 'Stores lamp entities and their current status';
+COMMENT ON COLUMN lamps.id IS 'Unique identifier for the lamp';
+COMMENT ON COLUMN lamps.status IS 'Current status of the lamp (ON/OFF)';
+COMMENT ON COLUMN lamps.created_at IS 'Timestamp when the lamp was created';
+COMMENT ON COLUMN lamps.updated_at IS 'Timestamp when the lamp was last updated';
+COMMENT ON COLUMN lamps.deleted_at IS 'Timestamp when the lamp was soft deleted, NULL if active';
+
+-- Create indexes
+CREATE INDEX IF NOT EXISTS idx_lamps_status ON lamps (status);
+CREATE INDEX IF NOT EXISTS idx_lamps_created_at ON lamps (created_at);
+CREATE INDEX IF NOT EXISTS idx_lamps_deleted_at ON lamps (deleted_at);
+
+-- Create updated_at trigger
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER update_lamps_updated_at
+    BEFORE UPDATE ON lamps
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column(); 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+version: '3.8'
+
 services:
   mysql:
     image: mysql:8.0
@@ -50,6 +52,15 @@ services:
     volumes:
       - ./database/mongodb/init.js:/docker-entrypoint-initdb.d/init.js:ro
       - mongo_data:/data/db
+
+  sql-lint:
+    build:
+      context: .
+      dockerfile: tools/sql-lint/Dockerfile
+    volumes:
+      - ./database/sql:/sql
+      - ./.sqlfluff:/sql/.sqlfluff
+    command: lint
 
   test:
     image: ubuntu:22.04

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,84 @@
+services:
+  mysql:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: lamp_control
+      MYSQL_USER: lamp_user
+      MYSQL_PASSWORD: lamp_password
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "lamp_user", "--password=lamp_password"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    ports:
+      - "3306:3306"
+    volumes:
+      - ./database/sql/mysql:/docker-entrypoint-initdb.d
+      - mysql_data:/var/lib/mysql
+
+  postgres:
+    image: postgres:13
+    environment:
+      POSTGRES_DB: lamp_control
+      POSTGRES_USER: lamp_user
+      POSTGRES_PASSWORD: lamp_password
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U lamp_user -d lamp_control"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./database/sql/postgresql:/docker-entrypoint-initdb.d
+      - postgres_data:/var/lib/postgresql/data
+
+  mongodb:
+    image: mongo:5.0
+    environment:
+      MONGO_INITDB_DATABASE: lamp_control
+      MONGO_INITDB_ROOT_USERNAME: lamp_user
+      MONGO_INITDB_ROOT_PASSWORD: lamp_password
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    ports:
+      - "27017:27017"
+    volumes:
+      - ./database/mongodb/init.js:/docker-entrypoint-initdb.d/init.js:ro
+      - mongo_data:/data/db
+
+  test:
+    image: ubuntu:22.04
+    depends_on:
+      mysql:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      mongodb:
+        condition: service_healthy
+    volumes:
+      - ./test-databases.sh:/test-databases.sh
+    command: >
+      bash -c "
+        apt-get update &&
+        apt-get install -y mysql-client postgresql-client curl &&
+        curl -fsSL https://pgp.mongodb.com/server-7.0.asc | gpg -o /usr/share/keyrings/mongodb-server-7.0.gpg --dearmor &&
+        echo 'deb [signed-by=/usr/share/keyrings/mongodb-server-7.0.gpg] http://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse' | tee /etc/apt/sources.list.d/mongodb-org-7.0.list &&
+        apt-get update &&
+        apt-get install -y mongodb-mongosh &&
+        chmod +x /test-databases.sh &&
+        /test-databases.sh
+      "
+    environment:
+      - MYSQL_HOST=mysql
+      - POSTGRES_HOST=postgres
+      - MONGODB_HOST=mongodb
+
+volumes:
+  mysql_data:
+  postgres_data:
+  mongo_data: 

--- a/docs/adr/001-lamp-status-boolean.md
+++ b/docs/adr/001-lamp-status-boolean.md
@@ -1,0 +1,93 @@
+# ADR 001: Use Boolean for Lamp Status
+
+## Status
+Accepted
+
+## Context
+The lamp control system needs to track the state of each lamp (on/off). Initially, this was implemented using an ENUM type with values 'ON' and 'OFF'. However, this decision needed to be revisited for better efficiency and simplicity.
+
+## Decision
+We will use a boolean field (`is_on` in SQL, `isOn` in MongoDB) instead of an ENUM type for lamp status.
+
+### Implementation Details
+- MySQL: `is_on BOOLEAN NOT NULL DEFAULT FALSE`
+- PostgreSQL: `is_on BOOLEAN NOT NULL DEFAULT FALSE`
+- MongoDB: `isOn: boolean` with schema validation
+
+## Rationale
+
+### Advantages
+1. **Storage Efficiency**
+   - Boolean typically uses 1 bit vs. ENUM's multiple bytes
+   - More efficient indexing
+   - Smaller memory footprint
+
+2. **Type Safety**
+   - Native boolean type in most programming languages
+   - No need for string comparison
+   - Eliminates possibility of invalid states
+
+3. **Query Performance**
+   - Faster comparisons
+   - Better index utilization
+   - Simpler query optimization
+
+4. **Code Clarity**
+   - More intuitive in conditionals (`if (lamp.isOn)` vs `if (lamp.status === 'ON')`)
+   - Clearer semantic meaning
+   - Reduced chance of errors
+
+5. **Analytics Benefits**
+   - Easier aggregation queries
+   - Better compatibility with analytics tools
+   - Simpler boolean logic in reports
+
+### Disadvantages
+1. **Less Extensible**
+   - Adding new states would require schema changes
+   - Binary nature limits future state options
+
+2. **Migration Effort**
+   - Requires data migration for existing systems
+   - Need to update application code
+
+## Alternatives Considered
+
+### 1. ENUM Type
+```sql
+ENUM('ON', 'OFF')
+```
+- More readable in raw database queries
+- Easier to extend with new states
+- Larger storage footprint
+- String comparison overhead
+
+### 2. Integer with Constants
+```sql
+TINYINT(1)
+```
+- Similar storage benefits
+- Less semantic meaning
+- Potential for invalid values
+
+## Consequences
+
+### Positive
+- Improved performance
+- Better type safety
+- Cleaner code
+- Smaller storage footprint
+
+### Negative
+- Less flexible for future state additions
+- Migration needed for existing systems
+
+## Related Decisions
+- Database schema design
+- API response format
+- Query optimization strategies
+
+## Notes
+- Consider feature flags for transitioning existing systems
+- Monitor performance metrics after implementation
+- Document any migration scripts needed 

--- a/scripts/lint-sql.sh
+++ b/scripts/lint-sql.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Build the SQL linting image if needed
+docker-compose build sql-lint
+
+# Run the linter with the specified command (default: lint)
+docker-compose run --rm sql-lint ${1:-lint} 

--- a/test-databases.sh
+++ b/test-databases.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo "Testing database setups..."
+
+# Function to test MySQL
+test_mysql() {
+    echo -e "\n${GREEN}Testing MySQL...${NC}"
+    mysql -h${MYSQL_HOST:-mysql} -ulamp_user -plamp_password lamp_control -e "
+        SELECT 'Database connected successfully' as Status;
+        SHOW TABLES;
+        DESCRIBE lamps;
+        INSERT INTO lamps (is_on) VALUES (true);
+        SELECT * FROM lamps;
+    "
+}
+
+# Function to test PostgreSQL
+test_postgres() {
+    echo -e "\n${GREEN}Testing PostgreSQL...${NC}"
+    PGPASSWORD=lamp_password psql -h ${POSTGRES_HOST:-postgres} -U lamp_user -d lamp_control -c "
+        \echo 'Database connected successfully';
+        \dt
+        \d lamps;
+        INSERT INTO lamps (is_on) VALUES (true);
+        SELECT * FROM lamps;
+    "
+}
+
+# Function to test MongoDB
+test_mongodb() {
+    echo -e "\n${GREEN}Testing MongoDB...${NC}"
+    mongosh "mongodb://lamp_user:lamp_password@${MONGODB_HOST:-mongodb}:27017/lamp_control" --eval '
+        print("Database connected successfully");
+        db.lamps.getIndexes();
+        db.lamps.insertOne({
+            _id: UUID().toString(),
+            isOn: true,
+            createdAt: new Date(),
+            updatedAt: new Date()
+        });
+        db.lamps.find();
+    '
+}
+
+# No need to wait when using healthchecks
+echo "Starting tests..."
+
+# Run tests
+test_mysql
+test_postgres
+test_mongodb
+
+echo -e "\n${GREEN}All tests completed!${NC}" 


### PR DESCRIPTION
This PR adds SQL linting capabilities with automated code suggestions using reviewdog.

### Changes
- Added GitHub Actions workflow for SQL linting with reviewdog
- Added SQLFluff configuration for MySQL and PostgreSQL
- Added SQL linting script for local development
- Updated docker-compose with SQL linting service

### Features
- Automatic SQL linting on PRs
- Code suggestions using reviewdog
- Support for both MySQL and PostgreSQL dialects
- Local linting capability via Docker

### How to Use
1. **In Pull Requests:**
   - The workflow automatically runs on SQL file changes
   - Reviewdog will suggest fixes as PR comments

2. **Locally:**
   ```bash
   ./scripts/lint-sql.sh
   ```

Closes #1