### PR TITLE
Remove brightness and color properties from Lamp model

### DIFF
--- a/src/typescript/src/domain/models/Lamp.ts
+++ b/src/typescript/src/domain/models/Lamp.ts
@@ -63,18 +63,6 @@ export class Lamp {
     this.state = newState;
   }
 
-  setBrightness(brightness: number): void {
-    const newState = { ...this.state, brightness, updatedAt: new Date() };
-    LampStateSchema.parse(newState);
-    this.state = newState;
-  }
-
-  setColor(color: string): void {
-    const newState = { ...this.state, color, updatedAt: new Date() };
-    LampStateSchema.parse(newState);
-    this.state = newState;
-  }
-
   turnOn(): void {
     if (!this.state.isOn) {
       this.state = { ...this.state, isOn: true, updatedAt: new Date() };


### PR DESCRIPTION
## Description
This PR removes the `setBrightness` and `setColor` methods from the Lamp domain model as they were inconsistent with the Lamp state schema which doesn't include brightness or color properties.

## Changes
- Removed `setBrightness(brightness: number)` method
- Removed `setColor(color: string)` method

## Related Issues
Resolves inconsistency between model methods and the actual state schema

## Testing
- No functionality changes to existing code
- Model remains valid with only the supported properties

## Checklist
- [x] Code follows project's coding style
- [x] Changes are well-documented
- [x] Conventional commit message format used