### PR TITLE
Update typescript-metrics.js

### DIFF
--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -17,7 +17,7 @@ This document provides a comparison of the different language implementations in
 
 | Language    | App Lines | Test Lines | Test/App Ratio | Coverage % |
 |------------|-----------|------------|----------------|------------|
-| TypeScript | 827 | 26218 | 37.80 | 85 |
+| TypeScript | 827 | 511 | 0.55 | 85 |
 ## Test Coverage
 
 | Language | Coverage % |


### PR DESCRIPTION
This pull request refactors the `tools/typescript-metrics.js` script by improving path handling and removing the Halstead metrics functionality. The changes enhance reliability and simplify the codebase by focusing on line-of-code (LOC) metrics.

### Improvements to path handling:
* Updated `SRC_DIR`, `TEST_PATTERN`, and `APP_PATTERN` to use absolute paths via `path.resolve` and `path.join`, ensuring consistent and reliable path resolution.
* Modified `COMMON_IGNORES` to include absolute paths for better matching, particularly adding an explicit path to `node_modules`.

### Removal of Halstead metrics:
* Removed the `getDetailedHalsteadMetrics` function, eliminating the functionality for calculating Halstead complexity metrics.
* Updated the `runMetrics` function to exclude Halstead metrics from the generated report, focusing solely on LOC metrics.