### PR TITLE
Fix code coverage

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -12,6 +12,9 @@ on:
       - 'src/python/**'
       - '.github/workflows/python-ci.yml'
 
+permissions:
+  contents: write
+
 jobs:
   test:
     name: Test Python ${{ matrix.python-version }}
@@ -118,4 +121,13 @@ jobs:
         MYSQL_DATABASE: lamp_test
         MONGODB_URI: mongodb://localhost:27017/lamp_test
       run: |
-        poetry run pytest --cov=lamp_control --cov-report=xml
+        poetry run pytest --cov=src --cov-report=json:coverage/coverage.json
+
+    - name: Commit coverage summary
+      if: github.ref == 'refs/heads/main'
+      run: |
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+        git add -f coverage/coverage.json || true
+        git commit -m "chore: update coverage summary" || exit 0
+        git push

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -12,6 +12,9 @@ on:
       - 'src/typescript/**'
       - '.github/workflows/typescript.yml'
 
+permissions:
+  contents: write
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
@@ -90,6 +93,6 @@ jobs:
       run: |
         git config --global user.name 'github-actions[bot]'
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-        git add coverage/coverage-summary.json || true
+        git add -f coverage/coverage-summary.json || true
         git commit -m "chore: update coverage summary" || exit 0
         git push


### PR DESCRIPTION
This pull request updates CI workflows for Python and TypeScript projects to enhance permissions and improve coverage reporting. The changes include adding write permissions for contents, modifying coverage report formats, and ensuring proper handling of coverage files in commits.

### Workflow Permissions Updates:
* [`.github/workflows/python-ci.yml`](diffhunk://#diff-e032d65b558ae8a939d517d588bbba6f0bceb4c881720d9b6017aa97fd00cefaR15-R17): Added `contents: write` permission to the workflow to enable writing to the repository.
* [`.github/workflows/typescript.yml`](diffhunk://#diff-49782368fc4afbd0b5be05e65cc0a4677d70c2078d3206dbe6b347b19d41630cR15-R17): Added `contents: write` permission to the workflow to enable writing to the repository.

### Coverage Reporting Improvements:
* [`.github/workflows/python-ci.yml`](diffhunk://#diff-e032d65b558ae8a939d517d588bbba6f0bceb4c881720d9b6017aa97fd00cefaL121-R133): Changed the coverage report format from XML to JSON and updated the storage location to `coverage/coverage.json`. Added a step to commit and push the coverage summary to the repository if the workflow runs on the `main` branch.
* [`.github/workflows/typescript.yml`](diffhunk://#diff-49782368fc4afbd0b5be05e65cc0a4677d70c2078d3206dbe6b347b19d41630cL93-R96): Updated the `git add` command to use the `-f` flag when adding `coverage/coverage-summary.json`, ensuring the file is staged even if it is ignored by `.gitignore`.