### PR TITLE
chore: add force add step for coverage summary in CI workflows

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -123,6 +123,10 @@ jobs:
       run: |
         poetry run pytest --cov=src --cov-report=json:coverage/coverage.json
 
+    - name: Force add coverage summary
+      if: github.ref == 'refs/heads/main'
+      run: git add -f coverage/coverage.json
+
     - name: Create Pull Request for coverage summary
       if: github.ref == 'refs/heads/main'
       uses: peter-evans/create-pull-request@v6

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -88,6 +88,10 @@ jobs:
           exit 1
         fi
 
+    - name: Force add coverage summary
+      if: github.ref == 'refs/heads/main'
+      run: git add -f coverage/coverage-summary.json
+
     - name: Create Pull Request for coverage summary
       if: github.ref == 'refs/heads/main'
       uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
This pull request updates the CI workflows to ensure that coverage summary files are force-added to version control before creating pull requests. The changes apply to both Python and TypeScript workflows.

### Workflow Updates:

* [`.github/workflows/python-ci.yml`](diffhunk://#diff-e032d65b558ae8a939d517d588bbba6f0bceb4c881720d9b6017aa97fd00cefaR126-R129): Added a step to force-add the `coverage/coverage.json` file to version control when running on the `main` branch.
* [`.github/workflows/typescript.yml`](diffhunk://#diff-49782368fc4afbd0b5be05e65cc0a4677d70c2078d3206dbe6b347b19d41630cR91-R94): Added a step to force-add the `coverage/coverage-summary.json` file to version control when running on the `main` branch.