### PR TITLE
chore: update CI workflows to grant write permissions for pull requests

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   test:

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   build-and-test:


### PR DESCRIPTION
This pull request updates the permissions in two GitHub Actions workflow files to include `pull-requests: write`. This change ensures the workflows have the necessary permissions to interact with pull requests.

Workflow permission updates:

* [`.github/workflows/python-ci.yml`](diffhunk://#diff-e032d65b558ae8a939d517d588bbba6f0bceb4c881720d9b6017aa97fd00cefaR17): Added `pull-requests: write` permission under the `permissions` section.
* [`.github/workflows/typescript.yml`](diffhunk://#diff-49782368fc4afbd0b5be05e65cc0a4677d70c2078d3206dbe6b347b19d41630cR17): Added `pull-requests: write` permission under the `permissions` section.