### PR TITLE
Trigger coverage summary PR on workflow dispatch

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - 'src/python/**'
       - '.github/workflows/python-ci.yml'
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - 'src/typescript/**'
       - '.github/workflows/typescript.yml'
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
This pull request updates the CI workflows for Python and TypeScript projects to allow manual triggering via `workflow_dispatch` and modifies the conditions for creating pull requests with coverage summaries. The changes streamline the workflows and remove unnecessary steps.

### Workflow updates:

* [`.github/workflows/python-ci.yml`](diffhunk://#diff-e032d65b558ae8a939d517d588bbba6f0bceb4c881720d9b6017aa97fd00cefaR14): Added `workflow_dispatch` to enable manual triggering of the workflow.
* [`.github/workflows/typescript.yml`](diffhunk://#diff-49782368fc4afbd0b5be05e65cc0a4677d70c2078d3206dbe6b347b19d41630cR14): Added `workflow_dispatch` to enable manual triggering of the workflow.

### Coverage summary updates:

* [`.github/workflows/python-ci.yml`](diffhunk://#diff-e032d65b558ae8a939d517d588bbba6f0bceb4c881720d9b6017aa97fd00cefaL127-R129): Replaced the condition for creating a pull request for the coverage summary from `github.ref == 'refs/heads/main'` to `github.event_name == 'workflow_dispatch'`, and removed the step to force-add the coverage file.
* [`.github/workflows/typescript.yml`](diffhunk://#diff-49782368fc4afbd0b5be05e65cc0a4677d70c2078d3206dbe6b347b19d41630cL92-R94): Replaced the condition for creating a pull request for the coverage summary from `github.ref == 'refs/heads/main'` to `github.event_name == 'workflow_dispatch'`, and removed the step to force-add the coverage file.