### PR TITLE
Remove unnecessary permissions for pull requests in CI workflows

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -22,10 +22,8 @@ jobs:
     name: Test Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       checks: write
       issues: write
-      pull-requests: write    
     defaults:
       run:
         working-directory: src/python

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -21,10 +21,8 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       checks: write
       issues: write
-      pull-requests: write
     defaults:
       run:
         working-directory: src/typescript


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for Python and TypeScript by modifying the permissions configuration. The changes remove unnecessary permissions for better security and compliance.

Workflow updates:

* [`.github/workflows/python-ci.yml`](diffhunk://#diff-e032d65b558ae8a939d517d588bbba6f0bceb4c881720d9b6017aa97fd00cefaL25-L28): Removed `contents: read` and `pull-requests: write` permissions from the `jobs` configuration.
* [`.github/workflows/typescript.yml`](diffhunk://#diff-49782368fc4afbd0b5be05e65cc0a4677d70c2078d3206dbe6b347b19d41630cL24-L27): Removed `contents: read` and `pull-requests: write` permissions from the `jobs` configuration.