### PR TITLE
chore: restore write permissions for contents and pull requests in CI…

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -13,10 +13,6 @@ on:
       - '.github/workflows/python-ci.yml'
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   test:
     name: Test Python ${{ matrix.python-version }}
@@ -24,6 +20,8 @@ jobs:
     permissions:
       checks: write
       issues: write
+      contents: write
+      pull-requests: write    
     defaults:
       run:
         working-directory: src/python

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -23,6 +23,8 @@ jobs:
     permissions:
       checks: write
       issues: write
+      contents: write
+      pull-requests: write
     defaults:
       run:
         working-directory: src/typescript


### PR DESCRIPTION
This pull request updates the permissions configuration in GitHub Actions workflows for Python and TypeScript. The changes ensure that the `contents` and `pull-requests` permissions are explicitly set for both workflows.

Updates to GitHub Actions workflows:

* [`.github/workflows/python-ci.yml`](diffhunk://#diff-e032d65b558ae8a939d517d588bbba6f0bceb4c881720d9b6017aa97fd00cefaL16-R24): Moved `contents` and `pull-requests` permissions from the top-level `permissions` block to the `test` job's `permissions` block, ensuring proper scoping.
* [`.github/workflows/typescript.yml`](diffhunk://#diff-49782368fc4afbd0b5be05e65cc0a4677d70c2078d3206dbe6b347b19d41630cR26-R27): Added `contents` and `pull-requests` permissions to the `permissions` block of the `jobs` section.