### PR TITLE
Makefile for Openapi

### DIFF
--- a/src/java/Makefile
+++ b/src/java/Makefile
@@ -1,3 +1,5 @@
+# Makefile for generating and validating Java Spring server stubs from OpenAPI spec
+
 # Variables
 OPENAPI_GENERATOR_VERSION := v7.13.0
 OPENAPI_SPEC := docs/api/openapi.yaml
@@ -9,15 +11,16 @@ DOCKER_RUN := docker run --rm \
 	-v ${PWD}/../..:/local \
 	openapitools/openapi-generator-cli:${OPENAPI_GENERATOR_VERSION}
 
-.PHONY: generate clean validate
+.PHONY: generate clean validate help
 
-# Generate FastAPI server stub
+# Generate Spring server stub
 generate:
-	@echo "Generating FastAPI server stub..."
+	@echo "Generating Spring server stub..."
 	${DOCKER_RUN} generate \
 		-i /local/${OPENAPI_SPEC} \
 		-g ${GENERATOR_NAME} \
-		-o /local/${OUTPUT_DIR}
+		-o /local/${OUTPUT_DIR} \
+		--additional-properties=async=true,useSpringBoot3=true,useOptional=true,hideGenerationTimestamp=true,performBeanValidation=true
 
 # Clean generated files
 clean:
@@ -32,7 +35,7 @@ validate:
 # Help target
 help:
 	@echo "Available targets:"
-	@echo "  generate  - Generate FastAPI server stub"
+	@echo "  generate  - Generate Spring server stub"
 	@echo "  clean    - Remove generated files"
 	@echo "  validate - Validate OpenAPI specification"
 	@echo "  help     - Show this help message" 

--- a/src/java/Makefile
+++ b/src/java/Makefile
@@ -1,0 +1,38 @@
+# Variables
+OPENAPI_GENERATOR_VERSION := v7.13.0
+OPENAPI_SPEC := docs/api/openapi.yaml
+OUTPUT_DIR := src/java
+GENERATOR_NAME := spring
+
+# Docker command with common options
+DOCKER_RUN := docker run --rm \
+	-v ${PWD}/../..:/local \
+	openapitools/openapi-generator-cli:${OPENAPI_GENERATOR_VERSION}
+
+.PHONY: generate clean validate
+
+# Generate FastAPI server stub
+generate:
+	@echo "Generating FastAPI server stub..."
+	${DOCKER_RUN} generate \
+		-i /local/${OPENAPI_SPEC} \
+		-g ${GENERATOR_NAME} \
+		-o /local/${OUTPUT_DIR}
+
+# Clean generated files
+clean:
+	@echo "Cleaning generated files..."
+	rm -rf ${OUTPUT_DIR}/lamp_control_api
+
+# Validate OpenAPI specification
+validate:
+	@echo "Validating OpenAPI specification..."
+	${DOCKER_RUN} validate -i /local/${OPENAPI_SPEC}
+
+# Help target
+help:
+	@echo "Available targets:"
+	@echo "  generate  - Generate FastAPI server stub"
+	@echo "  clean    - Remove generated files"
+	@echo "  validate - Validate OpenAPI specification"
+	@echo "  help     - Show this help message" 

--- a/src/java/adr/004-async-request-handling.md
+++ b/src/java/adr/004-async-request-handling.md
@@ -1,0 +1,31 @@
+# ADR 004: Asynchronous Request Handling for HTTP APIs
+Status: Proposed
+Date: 2025-05-21
+
+Context:
+The application must expose HTTP APIs with well-defined response times and predictable concurrency behavior. The team must choose between handling requests synchronously (thread-per-request model) or asynchronously (via @Async, CompletableFuture, etc.) to optimize throughput and resource usage.
+
+Decision:
+We will use asynchronous request handling with @Async and CompletableFuture for non-blocking, I/O-intensive operations.
+
+Consequences:
+
+Allows better use of thread resources when performing downstream I/O (e.g., HTTP calls, database access).
+
+Enables scaling to higher concurrent loads without increasing the thread pool size excessively.
+
+Requires managing thread context (e.g., security, MDC) across threads.
+
+Adds complexity in exception handling and tracing compared to synchronous flows.
+
+Alternatives Considered:
+
+Synchronous (default Spring MVC): Simple, easy to debug, good for CPU-bound or low-throughput APIs. However, scales poorly under high latency.
+
+Reactive (Spring WebFlux): Fully non-blocking and more scalable under load, but requires deeper rethinking of programming style and ecosystem dependencies (see ADR 2).
+
+Rationale:
+
+Async handling with CompletableFuture offers a pragmatic middle ground: scalable for high-load scenarios without the steep learning curve and full-stack migration required for reactive programming.
+
+Allows gradual adoption in specific endpoints or services.

--- a/src/java/adr/005-imperative-vs-reactive-stack.md
+++ b/src/java/adr/005-imperative-vs-reactive-stack.md
@@ -1,0 +1,43 @@
+# ADR 005: Imperative Async vs Reactive (Flux/Mono) Stack
+Status: Proposed
+Date: 2025-05-21
+
+Context:
+We must decide whether to build the application using Spring Web MVC (imperative model with optional async) or Spring WebFlux (reactive stack using Project Reactor). The choice affects the entire programming model, compatibility with libraries, and operational observability.
+
+Decision:
+We will use Spring MVC with optional asynchronous programming (CompletableFuture). We will not adopt Spring WebFlux for the initial version of this project.
+
+Consequences:
+
+Keeps compatibility with a broad set of mature Spring ecosystem libraries (e.g., Spring Data JPA, security, actuator).
+
+Easier to onboard developers familiar with traditional Spring and Java paradigms.
+
+Avoids reactive-specific complexity in error handling, flow control (backpressure), and debugging.
+
+May not fully leverage non-blocking I/O benefits for extreme scalability; those can be revisited later for targeted services.
+
+Alternatives Considered:
+
+Spring WebFlux (Reactive + Flux/Mono):
+
+Pros: Fully non-blocking, better for thousands of concurrent I/O-bound connections (e.g., APIs, gateways, streaming).
+
+Cons: Requires reactive-compatible libraries, increased complexity in flow control and testability, less mature debugging tools.
+
+Rationale:
+
+The primary system workload is request/response with moderate to high I/O, not streaming or high-concurrency messaging.
+
+Async Spring MVC allows us to scale without full-stack reengineering.
+
+Reactive programming may be re-evaluated in future services (e.g., event-driven pipelines or streaming APIs) as needs evolve.
+
+References:
+
+Spring MVC Async Support
+
+Spring WebFlux vs Spring MVC
+
+Reactor Project


### PR DESCRIPTION
This pull request introduces a Makefile for generating and validating Java Spring server stubs from an OpenAPI specification and includes two architectural decision records (ADRs) to document key technical decisions. The changes primarily focus on improving development workflows and establishing guidelines for asynchronous programming and stack selection.

### Development Workflow Enhancements:
* [`src/java/Makefile`](diffhunk://#diff-60b7562404382730654efb559e2e2a2caac8d4fb91eb37786cdf893eadabb147R1-R41): Added a Makefile to automate the generation of Spring server stubs, clean up generated files, and validate the OpenAPI specification. This includes Docker-based commands for consistency and ease of use.

### Architectural Decision Records (ADRs):
* [`src/java/adr/004-async-request-handling.md`](diffhunk://#diff-29394da8d2bbb78e727f5e2863932668fd9efae05acbe6bb1cf853bb65086e8eR1-R31): Introduced ADR 004 to document the decision to use asynchronous request handling with `@Async` and `CompletableFuture` for non-blocking, I/O-intensive operations, balancing scalability and complexity.
* [`src/java/adr/005-imperative-vs-reactive-stack.md`](diffhunk://#diff-e5f44cb7391fbd865b65dd7840dc20e683f4801a731f5f0ee6365203a9344e1aR1-R43): Added ADR 005 to outline the decision to adopt Spring MVC with optional asynchronous programming instead of Spring WebFlux, prioritizing compatibility with the Spring ecosystem and developer familiarity.