### PR TITLE
chore: update test step to include coverage reporting

### DIFF
--- a/.github/workflows/java-code-quality.yml
+++ b/.github/workflows/java-code-quality.yml
@@ -50,9 +50,9 @@ jobs:
       working-directory: ./src/java
       run: mvn checkstyle:check
     
-    - name: Run tests
+    - name: Run tests with coverage
       working-directory: ./src/java
-      run: mvn test
+      run: mvn test jacoco:report
     
     - name: Generate SpotBugs report
       working-directory: ./src/java
@@ -68,3 +68,11 @@ jobs:
       working-directory: ./src/java
       run: mvn checkstyle:checkstyle
       if: always()
+
+    - name: Create Pull Request for coverage summary
+      if: github.event_name == 'workflow_dispatch'
+      uses: peter-evans/create-pull-request@v6
+      with:
+        commit-message: "chore: update coverage summary"
+        title: "chore: update coverage summary"
+        branch: "ci/java-coverage-update"


### PR DESCRIPTION
This pull request updates the Java code quality workflow to enhance test coverage reporting and automate coverage summary updates. The most important changes include adding test coverage generation using JaCoCo and automating the creation of pull requests for coverage summaries.

### Enhancements to test coverage reporting:
* Updated the "Run tests" step to include JaCoCo coverage generation by changing the command from `mvn test` to `mvn test jacoco:report`. (`.github/workflows/java-code-quality.yml`, [.github/workflows/java-code-quality.ymlL53-R55](diffhunk://#diff-a8bfc3933a371615cb0ce936f82d53871ba770a123d5cca3b1be30e7e0d23e43L53-R55))

### Automation for coverage summary updates:
* Added a new step to the workflow to create a pull request for coverage summary updates using the `peter-evans/create-pull-request` action. This step runs only when triggered by a `workflow_dispatch` event. (`.github/workflows/java-code-quality.yml`, [.github/workflows/java-code-quality.ymlR71-R78](diffhunk://#diff-a8bfc3933a371615cb0ce936f82d53871ba770a123d5cca3b1be30e7e0d23e43R71-R78))