### PR TITLE
Java fix coverage

### DIFF
--- a/.github/workflows/update-metrics.yml
+++ b/.github/workflows/update-metrics.yml
@@ -90,6 +90,27 @@ jobs:
           echo "Python coverage: $PY_COVERAGE"
           echo "PY_COVERAGE=$PY_COVERAGE" >> $GITHUB_ENV
 
+          # Java coverage
+          if [ -f src/java/target/site/jacoco/jacoco.xml ]; then
+            # Extract line coverage from JaCoCo XML (final counters for lines)
+            JAVA_MISSED=$(xmllint --xpath "//report/counter[@type='LINE']/@missed" src/java/target/site/jacoco/jacoco.xml | grep -o '[0-9]*')
+            JAVA_COVERED=$(xmllint --xpath "//report/counter[@type='LINE']/@covered" src/java/target/site/jacoco/jacoco.xml | grep -o '[0-9]*')
+            if [[ "$JAVA_MISSED" =~ ^[0-9]+$ && "$JAVA_COVERED" =~ ^[0-9]+$ ]]; then
+              JAVA_TOTAL=$((JAVA_MISSED + JAVA_COVERED))
+              if [ "$JAVA_TOTAL" -gt 0 ]; then
+                JAVA_COVERAGE=$(awk "BEGIN {printf \"%.0f\", ($JAVA_COVERED/$JAVA_TOTAL)*100}")
+              else
+                JAVA_COVERAGE="0"
+              fi
+            else
+              JAVA_COVERAGE="N/A"
+            fi
+          else
+            JAVA_COVERAGE="N/A"
+          fi
+          echo "Java coverage: $JAVA_COVERAGE"
+          echo "JAVA_COVERAGE=$JAVA_COVERAGE" >> $GITHUB_ENV
+
       - name: Generate SCC table
         run: |
           echo "| Language   | App Lines | Test Lines | Test/App Ratio | Coverage (%) |" > tools/metrics.md
@@ -115,6 +136,8 @@ jobs:
               coverage="${TS_COVERAGE:-N/A}"
             elif [[ "$lang_name" == "Python" ]]; then
               coverage="${PY_COVERAGE:-N/A}"
+            elif [[ "$lang_name" == "Java" ]]; then
+              coverage="${JAVA_COVERAGE:-N/A}"
             else
               coverage="N/A"
             fi

--- a/src/java/.gitignore
+++ b/src/java/.gitignore
@@ -24,6 +24,7 @@ hs_err_pid*
 replay_pid*
 
 target/
+!target/site/jacoco/jacoco.xml
 pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup

--- a/src/java/pom.xml
+++ b/src/java/pom.xml
@@ -303,20 +303,6 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>report-json</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/site/jacoco-json</outputDirectory>
-                            <dataFile>${project.build.directory}/jacoco.exec</dataFile>
-                            <formats>
-                                <format>XML</format>
-                            </formats>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>check</id>
                         <goals>
                             <goal>check</goal>


### PR DESCRIPTION
This pull request introduces Java code coverage reporting to the CI workflow, adjusts `.gitignore` to include JaCoCo XML reports, and removes redundant JaCoCo execution configurations in the Maven `pom.xml`. Below is a summary of the most important changes:

### CI Workflow Enhancements:
* Added Java code coverage extraction using JaCoCo XML reports in the GitHub Actions workflow. The script calculates coverage percentages and exports the result as an environment variable (`JAVA_COVERAGE`) for use in subsequent steps. (`.github/workflows/update-metrics.yml`, [.github/workflows/update-metrics.ymlR93-R113](diffhunk://#diff-0689bdefcedde58d938dc97253029debb832a5de2ec4827e4ff238fb50e847ceR93-R113))
* Updated the metrics table generation logic to include Java coverage data by referencing the `JAVA_COVERAGE` variable. (`.github/workflows/update-metrics.yml`, [.github/workflows/update-metrics.ymlR139-R140](diffhunk://#diff-0689bdefcedde58d938dc97253029debb832a5de2ec4827e4ff238fb50e847ceR139-R140))

### Configuration and Build Adjustments:
* Updated `.gitignore` to allow the inclusion of JaCoCo XML reports (`target/site/jacoco/jacoco.xml`) while ignoring other files in the `target/` directory. (`src/java/.gitignore`, [src/java/.gitignoreR27](diffhunk://#diff-d61d4d38b4e3e118b458edd5fd81c9ec9a948e44d454e4d806a100a65a01ba7cR27))
* Removed a redundant JaCoCo execution configuration for generating JSON reports in the Maven `pom.xml`, leaving only the necessary configurations for XML reports and checks. (`src/java/pom.xml`, [src/java/pom.xmlL305-L318](diffhunk://#diff-a3f85e2a6638b97fdfee86e87422cbd321fde30a6aeb6f041a82f510fb3d75aeL305-L318))