### PR TITLE
feat: add ADR documents for PHP version and framework selection

### DIFF
--- a/src/php/adr/001-php-version.md
+++ b/src/php/adr/001-php-version.md
@@ -1,0 +1,36 @@
+# ADR-001: Choose PHP Version for New Project
+
+**Status:** Accepted
+**Date:** 2025-05-25
+**Context:**
+We are starting a new PHP project and must select the PHP version to ensure maximum support, compatibility, and access to recent features. The project aims for stability, maintainability, and community support over the next several years.
+
+**Decision:**
+We will use **PHP 8.3** as the runtime version for this project.
+
+**Consequences:**
+
+* **Security & Support:** PHP 8.3 is the latest stable release, actively maintained, with security updates until November 2026.
+* **Modern Features:** Enables usage of the latest language features and performance enhancements.
+* **Community & Ecosystem:** All major PHP frameworks (e.g., Laravel, Symfony) and libraries are compatible.
+* **Deployment:** Most major cloud providers and hosts support PHP 8.3.
+* **Future-Proofing:** Early adoption of PHP 8.4 is not recommended as it is not yet released/stable.
+
+**Alternatives Considered:**
+
+* **PHP 8.2:** Support ends December 2025; shorter maintenance window.
+* **Older Versions (8.1, 8.0, 7.x):** End of life; no security or active support.
+* **PHP 8.4:** Not yet released/stable as of this decision.
+
+**Risks:**
+
+* Some legacy or poorly maintained libraries may not yet be fully compatible with PHP 8.3, though this risk is minor given the maturity of the ecosystem.
+
+**References:**
+
+* [PHP Supported Versions](https://www.php.net/supported-versions.php)
+* [PHP 8.3 Release Announcement](https://www.php.net/releases/8.3/)
+
+---
+
+Let me know if you need this customized for a specific project, or if you want a Markdown file or a Notion-ready version.

--- a/src/php/adr/002-php-framework.md
+++ b/src/php/adr/002-php-framework.md
@@ -1,0 +1,41 @@
+# ADR-002: Select PHP Framework and Version for REST API
+
+**Status:** Accepted
+**Date:** 2025-05-26
+
+## Context
+
+We are initiating a new PHP project with the primary objective of building a robust, maintainable, and scalable REST API. The framework choice should enable rapid development, ensure security, and provide strong community and ecosystem support over the coming years.
+
+## Decision
+
+We will use **Laravel 12** as the framework for our REST API.
+
+* **Version:** Laravel 12 (released on February 24, 2025)
+* **PHP Compatibility:** PHP 8.2, 8.3, and 8.4
+
+## Rationale
+
+* **Latest Stable Release:** Laravel 12 is the most recent stable version, ensuring access to the latest features and improvements.
+* **Support Timeline:** Laravel 12 will receive bug fixes until August 13, 2026, and security updates until February 24, 2027.
+* **Enhanced Features:** Laravel 12 introduces improved application structure, new starter kits for Vue, React, and Livewire, and advanced API features like GraphQL support and better versioning.
+* **Community and Ecosystem:** Laravel has a large and active community, with extensive documentation and a rich ecosystem of packages and tools.
+* **Performance and Scalability:** Laravel 12 includes performance optimizations and supports asynchronous processing via Laravel Octane for high-throughput API needs.
+
+## Alternatives Considered
+
+* **Laravel 11:** While still supported, Laravel 11 will receive bug fixes only until August 5, 2025, and security updates until February 3, 2026, making Laravel 12 a more future-proof choice.
+* **Symfony:** Highly modular and robust, ideal for complex, enterprise APIs, but has a steeper learning curve and requires more boilerplate.
+* **Slim:** Lightweight and fast, suited for microservices, but lacks many features and requires additional packages for full API functionality.
+* **API Platform:** Built on Symfony, specialized for API-first projects (REST & GraphQL), but introduces additional complexity.
+
+## Risks
+
+* **Ecosystem Maturity:** As Laravel 12 is a recent release, some third-party packages may not yet be fully compatible.
+* **Learning Curve:** New features and changes in Laravel 12 may require additional learning and adaptation time for the development team.
+
+## References
+
+* [Laravel 12 Release Notes](https://laravel.com/docs/12.x/releases)
+* [Laravel Versions and Support Policy](https://laravelversions.com/en)
+* [Laravel 12 Features and Updates](https://www.bacancytechnology.com/blog/laravel-12-features-updates)


### PR DESCRIPTION
This pull request introduces two new Architecture Decision Records (ADRs) to document key technical decisions for a new PHP project. The first ADR selects PHP 8.3 as the project's runtime version, and the second ADR chooses Laravel 12 as the framework for building the REST API. These decisions prioritize modern features, long-term support, and ecosystem compatibility.

### PHP Version Selection (ADR-001)
* **Decision:** Use PHP 8.3 as the runtime version for the project, citing its active maintenance, modern features, and broad ecosystem support.
* **Alternatives:** Older PHP versions (8.2 and below) were rejected due to shorter support windows or end-of-life status, and PHP 8.4 was deemed too early for adoption.
* **Risks:** Minor risk of incompatibility with legacy libraries, though mitigated by the ecosystem's maturity.

### PHP Framework Selection (ADR-002)
* **Decision:** Use Laravel 12 for the REST API, leveraging its latest features, strong community, and scalability improvements.
* **Alternatives:** Laravel 11, Symfony, Slim, and API Platform were considered but rejected due to shorter support timelines, higher complexity, or limited functionality.
* **Risks:** Potential compatibility issues with third-party packages and a learning curve for new features in Laravel 12.