### PR TITLE
feat: add ADRs for Ruby version and framework selection for new proje…

### DIFF
--- a/src/ruby/adr/001-ruby-version.md
+++ b/src/ruby/adr/001-ruby-version.md
@@ -1,0 +1,36 @@
+# ADR: Select Ruby Version for New Project
+
+**Status:** Accepted
+**Date:** 2025-05-26
+
+## Context
+
+We are starting a new Ruby project in 2025 and must choose the Ruby version to use as our runtime. The Ruby language releases a new major version every December and maintains each release for roughly three years, with the last two to three versions receiving security and critical bug fixes. Ruby does **not** have a formal LTS (Long-Term Support) program, but recent versions are actively maintained.
+
+## Decision
+
+We will use **Ruby 3.4.x** as the language runtime for this project.
+
+## Rationale
+
+* **Latest stable release:** Ruby 3.4, released December 25, 2024, is the newest stable version and includes the latest language features, performance improvements, and security fixes.
+* **Community and ecosystem support:** All major gems and frameworks are compatible with Ruby 3.4, ensuring smooth development and maintenance.
+* **Maintenance and security:** Ruby 3.4 will receive official updates and security patches until at least March 2028, providing a stable window for project development and deployment.
+* **No formal LTS:** Ruby does not designate LTS versions. The best practice is to use the latest stable release for new projects.
+* **Forward compatibility:** Using the latest version reduces the technical debt and effort required for future upgrades.
+
+## Consequences
+
+* The project will benefit from new features and improved performance introduced in Ruby 3.4.
+* We will need to monitor future Ruby releases and plan for regular upgrades (every 2–3 years) to remain within the supported window.
+* Older systems and gems that do not support Ruby 3.4 may need to be upgraded or replaced.
+
+## Alternatives Considered
+
+* **Ruby 3.3 or 3.2:** Would extend compatibility for teams with strict dependencies, but these versions will reach end-of-life sooner and lack the latest features and improvements.
+* **Waiting for a future release:** Delaying would not be practical and would result in missing the benefits of current improvements.
+
+---
+
+**Decision:**
+**Use Ruby 3.4.x as the runtime for all new Ruby projects started in 2025.**

--- a/src/ruby/adr/002-ruby-framework.md
+++ b/src/ruby/adr/002-ruby-framework.md
@@ -1,0 +1,49 @@
+# ADR: Select Framework for Building a REST API in Ruby (2025)
+
+**Status:** Accepted
+**Date:** 2025-05-26
+
+## Context
+
+We are starting a new REST API project in Ruby in 2025. Ruby offers several frameworks suited to API development, each with different trade-offs regarding ecosystem support, scalability, maintainability, and performance.
+
+The most widely used Ruby frameworks for REST APIs are:
+
+* **Rails (Ruby on Rails)**
+* **Hanami**
+* **Sinatra**
+* **Roda**
+* **Grape**
+
+## Decision
+
+We will use **Ruby on Rails (API-only mode)** as the framework for this project.
+
+## Rationale
+
+* **Maturity & Community:** Rails is the most mature Ruby web framework, with a large ecosystem and community. Most Ruby developers are familiar with Rails conventions.
+* **API Mode:** Rails API-only mode strips out view and frontend components, providing a lightweight, streamlined experience for building APIs.
+* **Tooling & Ecosystem:** Outstanding libraries, documentation, plugins, and built-in features (e.g., ActiveRecord, migrations, testing).
+* **Scalability:** Suitable for both small APIs and large-scale production systems.
+* **Hiring:** Easiest to find developers with Rails experience.
+* **Support:** Rails is actively maintained and keeps up with new Ruby versions.
+
+### Alternatives Considered
+
+* **Hanami:** A modern, modular, and clean alternative with growing popularity. Strong architectural principles and performance. Not chosen primarily due to smaller community/ecosystem and fewer ready-to-use plugins compared to Rails.
+* **Sinatra:** Ideal for ultra-lightweight or prototype APIs. Not chosen for this project, as we expect to benefit from Rails’ features and conventions in the long term.
+* **Roda:** Very fast and minimalist, best suited for performance-critical or microservice use cases. Not chosen as we value ecosystem and maintainability more for this project.
+* **Grape:** API-focused framework often used as a plugin in other frameworks; less common as a standalone choice.
+
+## Consequences
+
+* The project benefits from a mature, stable, and well-documented framework.
+* Rapid development with minimal boilerplate for API needs.
+* Easy onboarding of new developers due to Rails’ popularity.
+* Slightly higher baseline resource usage than the most minimal frameworks, but offset by maintainability and scalability benefits.
+* If future needs arise (such as adding a web frontend), Rails provides a clear upgrade path.
+
+---
+
+**Decision:**
+**Use Ruby on Rails (API-only mode) as the framework for the new REST API. Reevaluate if project requirements shift toward minimalism or modularity (Hanami/Sinatra).**


### PR DESCRIPTION
This pull request introduces two Architectural Decision Records (ADRs) to document key technical choices for a new Ruby project starting in 2025. The first ADR selects the Ruby version, and the second ADR chooses the framework for building a REST API. These decisions aim to ensure stability, maintainability, and alignment with community standards.

### Ruby Version Selection:
* **ADR 001 (`src/ruby/adr/001-ruby-version.md`)**: Decides to use Ruby 3.4.x as the runtime for the project. This version is the latest stable release, offering new features, performance improvements, and security updates, with official support until at least 2028.

### Framework Selection:
* **ADR 002 (`src/ruby/adr/002-ruby-framework.md`)**: Chooses Ruby on Rails in API-only mode as the framework for the REST API. Rails was selected for its maturity, large ecosystem, developer familiarity, and scalability, making it a strong choice for both small and large-scale systems.