### PR TITLE
Remove PDO dependency registration

### DIFF
--- a/src/php/lamp-control-api/lib/App/RegisterDependencies.php
+++ b/src/php/lamp-control-api/lib/App/RegisterDependencies.php
@@ -66,15 +66,6 @@ final class RegisterDependencies
 
             \Neomerx\Cors\Contracts\AnalyzerInterface::class => \DI\factory([\Neomerx\Cors\Analyzer::class, 'instance']),
 
-            // PDO class for database managing
-            \PDO::class => \DI\create()
-                ->constructor(
-                    \DI\get('pdo.dsn'),
-                    \DI\get('pdo.username'),
-                    \DI\get('pdo.password'),
-                    \DI\get('pdo.options')
-                ),
-
             // DataMocker
             // @see https://github.com/ybelenko/openapi-data-mocker-server-middleware
             \OpenAPIServer\Mock\OpenApiDataMockerInterface::class => \DI\create(\OpenAPIServer\Mock\OpenApiDataMocker::class)


### PR DESCRIPTION
The registration of the PDO class as a dependency has been removed from RegisterDependencies.php. This may indicate a change in how database connections are managed or configured in the application.