### PR TITLE
Update openapi

### DIFF
--- a/docs/adr/002-pagination-strategy.md
+++ b/docs/adr/002-pagination-strategy.md
@@ -1,0 +1,37 @@
+# ADR 002: Pagination Strategy
+
+## Context
+
+To handle large datasets efficiently and provide a better user experience, the API needs a consistent and scalable pagination strategy. This is particularly important for endpoints that return lists of resources.
+
+## Decision
+
+The API will use cursor-based pagination for all list endpoints. This approach provides better performance and flexibility compared to offset-based pagination, especially for datasets that are frequently updated.
+
+### Implementation Details
+
+1. **Query Parameters**:
+   - `cursor`: A string representing the position in the dataset.
+   - `pageSize`: An integer specifying the number of items to return (default: 25, min: 1, max: 100).
+
+2. **Response Structure**:
+   - `data`: An array of resources.
+   - `nextCursor`: A string representing the cursor for the next page (nullable if no more data).
+   - `hasMore`: A boolean indicating if more data is available.
+
+3. **Endpoints**:
+   - All list endpoints will support these parameters and response structure.
+
+## Consequences
+
+- **Pros**:
+  - Efficient for large datasets.
+  - Avoids issues with data consistency during pagination.
+  - Flexible for various use cases.
+
+- **Cons**:
+  - Slightly more complex to implement compared to offset-based pagination.
+
+## Status
+
+Accepted

--- a/docs/adr/003-offline-first-api.md
+++ b/docs/adr/003-offline-first-api.md
@@ -1,0 +1,40 @@
+# ADR 003: Offline-First API
+
+## Context
+
+To improve the reliability and user experience of the API, especially in scenarios with intermittent or no network connectivity, the API should support an offline-first approach. This ensures that clients can function seamlessly even when the network is unavailable.
+
+## Decision
+
+The API will adopt an offline-first strategy by leveraging caching mechanisms and conditional requests. This approach will prioritize local data availability and minimize unnecessary network calls.
+
+### Implementation Details
+
+1. **ETag Support**:
+   - All read endpoints will include ETag headers in their responses.
+   - Clients can use the `If-None-Match` header to perform conditional requests, reducing bandwidth usage and improving performance.
+
+2. **Caching**:
+   - Clients are encouraged to cache responses locally.
+   - The API will provide appropriate cache-control headers to guide caching behavior.
+
+3. **Conflict Resolution**:
+   - For write operations, clients should handle conflicts gracefully by retrying or merging changes when necessary.
+
+4. **Error Handling**:
+   - The API will return meaningful error codes and messages to help clients handle offline scenarios effectively.
+
+## Consequences
+
+- **Pros**:
+  - Improved user experience in offline or low-connectivity environments.
+  - Reduced server load and bandwidth usage.
+  - Enhanced performance for read operations.
+
+- **Cons**:
+  - Increased complexity in client-side implementation.
+  - Potential challenges in conflict resolution for write operations.
+
+## Status
+
+Accepted

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -20,6 +20,12 @@ paths:
         - in: query
           name: pageSize
           schema: { type: integer, minimum: 1, maximum: 100, default: 25 }
+        - name: If-None-Match
+          in: header
+          required: false
+          schema:
+            type: string
+            description: The ETag value to check for conditional requests
       responses:
         '200':
           description: A list of lamps with pagination
@@ -37,6 +43,8 @@ paths:
                     nullable: true
                   hasMore:
                     type: boolean
+        '304':
+          description: Not Modified
     post:
       summary: Create a new lamp
       operationId: createLamp
@@ -81,6 +89,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: If-None-Match
+          in: header
+          required: false
+          schema:
+            type: string
+            description: The ETag value to check for conditional requests
       responses:
         '200':
           description: Lamp details
@@ -88,6 +102,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Lamp'
+        '304':
+          description: Not Modified
         '400':
           description: Invalid lamp ID format
           content:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -13,15 +13,30 @@ paths:
     get:
       summary: List all lamps
       operationId: listLamps
+      parameters:
+        - in: query
+          name: cursor
+          schema: { type: string, nullable: true }
+        - in: query
+          name: pageSize
+          schema: { type: integer, minimum: 1, maximum: 100, default: 25 }
       responses:
         '200':
-          description: A list of lamps
+          description: A list of lamps with pagination
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Lamp'
+                type: object
+                required: [data, hasMore]
+                properties:
+                  data:
+                    type: array
+                    items: { $ref: '#/components/schemas/Lamp' }
+                  nextCursor:
+                    type: string
+                    nullable: true
+                  hasMore:
+                    type: boolean
     post:
       summary: Create a new lamp
       operationId: createLamp

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -178,14 +178,5 @@ components:
           type: string
           description: Error type identifier
           example: "INVALID_ARGUMENT"
-        message:
-          type: string
-          description: Human-readable error message
-          example: "The request contains invalid parameters or malformed data"
-        details:
-          type: string
-          description: Additional error details or context
-          example: "Invalid format for parameter 'status': expected boolean"
       required:
         - error
-        - message

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -40,6 +40,13 @@ paths:
     post:
       summary: Create a new lamp
       operationId: createLamp
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+            description: A unique key to ensure idempotency of the request
       requestBody:
         required: true
         content:
@@ -102,6 +109,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+            description: A unique key to ensure idempotency of the request
       requestBody:
         required: true
         content:
@@ -136,6 +149,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+            description: A unique key to ensure idempotency of the request
       responses:
         '204':
           description: Lamp deleted successfully

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -164,10 +164,20 @@ components:
         status:
           type: boolean
           description: Whether the lamp is turned on (true) or off (false)
+        createdAt:
+          type: string
+          format: date-time
+          description: Timestamp when the lamp was created
+        updatedAt:
+          type: string
+          format: date-time
+          description: Timestamp when the lamp was last updated
       required:
         - id
         - status
-    
+        - createdAt
+        - updatedAt
+
     LampCreate:
       type: object
       properties:
@@ -176,16 +186,21 @@ components:
           description: Initial status of the lamp (on/off)
       required:
         - status
-    
+
     LampUpdate:
       type: object
       properties:
         status:
           type: boolean
           description: New status of the lamp (on/off)
+        updatedAt:
+          type: string
+          format: date-time
+          description: Timestamp when the lamp was last updated
       required:
         - status
-    
+        - updatedAt
+
     Error:
       type: object
       properties:


### PR DESCRIPTION
This pull request introduces two new architectural decision records (ADRs) and updates the OpenAPI specification to support cursor-based pagination, offline-first API features, idempotency, and improved resource metadata for the lamp API. The main changes are grouped below by theme.

**API Pagination and Offline-First Enhancements:**

* Added ADR 002 describing the decision to use cursor-based pagination for all list endpoints, including query parameters (`cursor`, `pageSize`) and a standardized response structure (`data`, `nextCursor`, `hasMore`).
* Added ADR 003 outlining an offline-first API strategy, including ETag support, caching recommendations, conditional requests, and error handling for offline scenarios.
* Updated the OpenAPI spec for the lamp list endpoint to support cursor-based pagination parameters and response, and to include the `If-None-Match` header for conditional requests.
* Updated the lamp detail endpoint to support the `If-None-Match` header and 304 Not Modified responses, enabling conditional GETs.

**Idempotency Improvements:**

* Added optional `Idempotency-Key` header to POST, PUT, and DELETE lamp endpoints to support idempotent operations and prevent duplicate resource creation or modification. [[1]](diffhunk://#diff-74cef0eb85871a2bdadbb8cf61dadd482c7c13c65ccde24511ffad15b66ae70cR16-R57) [[2]](diffhunk://#diff-74cef0eb85871a2bdadbb8cf61dadd482c7c13c65ccde24511ffad15b66ae70cR128-R133) [[3]](diffhunk://#diff-74cef0eb85871a2bdadbb8cf61dadd482c7c13c65ccde24511ffad15b66ae70cR168-R173)

**Resource Metadata and Schema Updates:**

* Added `createdAt` and `updatedAt` fields to the `Lamp` and `LampUpdate` schemas to provide resource creation and modification timestamps. [[1]](diffhunk://#diff-74cef0eb85871a2bdadbb8cf61dadd482c7c13c65ccde24511ffad15b66ae70cR202-R214) [[2]](diffhunk://#diff-74cef0eb85871a2bdadbb8cf61dadd482c7c13c65ccde24511ffad15b66ae70cR231-R237)

**Error Schema Simplification:**

* Simplified the `Error` schema by removing the `message` and `details` fields, leaving only the `error` type identifier.