### PR TITLE
Fix PHP

### DIFF
--- a/src/php/lamp-control-api/lib/Api/DefaultApi.php
+++ b/src/php/lamp-control-api/lib/Api/DefaultApi.php
@@ -24,6 +24,17 @@ class DefaultApi extends AbstractDefaultApi
     {
         $data = json_decode((string)$request->getBody(), true);
 
+        // Validate JSON parsing
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            $errorData = [
+                'error' => 'INVALID_ARGUMENT',
+                'message' => 'Invalid JSON format',
+                'details' => json_last_error_msg()
+            ];
+            $response->getBody()->write(json_encode($errorData));
+            return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
+        }
+
         // Check if data is null or not an array (empty body returns null)
         if ($data === null || !is_array($data)) {
             $errorData = [
@@ -32,6 +43,41 @@ class DefaultApi extends AbstractDefaultApi
             ];
             $response->getBody()->write(json_encode($errorData));
             return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
+        }
+
+        // Check if it's an indexed array (not an associative array/object)
+        if (array_keys($data) === range(0, count($data) - 1)) {
+            $errorData = [
+                'error' => 'INVALID_ARGUMENT',
+                'message' => 'The request contains invalid parameters or malformed data',
+                'details' => 'Request body must be a JSON object, not an array'
+            ];
+            $response->getBody()->write(json_encode($errorData));
+            return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
+        }
+
+        // Validate field names - reject empty string keys or invalid field names
+        foreach (array_keys($data) as $fieldName) {
+            if ($fieldName === '') {
+                $errorData = [
+                    'error' => 'INVALID_ARGUMENT',
+                    'message' => 'The request contains invalid parameters or malformed data',
+                    'details' => 'Field names cannot be empty strings'
+                ];
+                $response->getBody()->write(json_encode($errorData));
+                return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
+            }
+
+            // Only allow the 'status' field as per LampCreate schema
+            if ($fieldName !== 'status') {
+                $errorData = [
+                    'error' => 'INVALID_ARGUMENT',
+                    'message' => 'The request contains invalid parameters or malformed data',
+                    'details' => 'Unknown field: ' . $fieldName
+                ];
+                $response->getBody()->write(json_encode($errorData));
+                return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
+            }
         }
 
         // Check for required status field
@@ -100,6 +146,85 @@ class DefaultApi extends AbstractDefaultApi
         string $lampId
     ): ResponseInterface {
         $data = json_decode((string)$request->getBody(), true);
+
+        // Validate JSON parsing
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            $errorData = [
+                'error' => 'INVALID_ARGUMENT',
+                'message' => 'Invalid JSON format',
+                'details' => json_last_error_msg()
+            ];
+            $response->getBody()->write(json_encode($errorData));
+            return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
+        }
+
+        // Check if data is null or not an array (empty body returns null)
+        if ($data === null || !is_array($data)) {
+            $errorData = [
+                'error' => 'INVALID_ARGUMENT',
+                'message' => 'Request body must be a valid JSON object'
+            ];
+            $response->getBody()->write(json_encode($errorData));
+            return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
+        }
+
+        // Check if it's an indexed array (not an associative array/object)
+        if (array_keys($data) === range(0, count($data) - 1)) {
+            $errorData = [
+                'error' => 'INVALID_ARGUMENT',
+                'message' => 'The request contains invalid parameters or malformed data',
+                'details' => 'Request body must be a JSON object, not an array'
+            ];
+            $response->getBody()->write(json_encode($errorData));
+            return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
+        }
+
+        // Validate field names - reject empty string keys or invalid field names
+        foreach (array_keys($data) as $fieldName) {
+            if ($fieldName === '') {
+                $errorData = [
+                    'error' => 'INVALID_ARGUMENT',
+                    'message' => 'The request contains invalid parameters or malformed data',
+                    'details' => 'Field names cannot be empty strings'
+                ];
+                $response->getBody()->write(json_encode($errorData));
+                return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
+            }
+
+            // Only allow the 'status' field as per LampUpdate schema
+            if ($fieldName !== 'status') {
+                $errorData = [
+                    'error' => 'INVALID_ARGUMENT',
+                    'message' => 'The request contains invalid parameters or malformed data',
+                    'details' => 'Unknown field: ' . $fieldName
+                ];
+                $response->getBody()->write(json_encode($errorData));
+                return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
+            }
+        }
+
+        // Check for required status field
+        if (!array_key_exists('status', $data)) {
+            $errorData = [
+                'error' => 'INVALID_ARGUMENT',
+                'message' => 'The request contains invalid parameters or malformed data',
+                'details' => 'Missing required field: status'
+            ];
+            $response->getBody()->write(json_encode($errorData));
+            return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
+        }
+
+        // Validate status field type
+        if (!is_bool($data['status'])) {
+            $errorData = [
+                'error' => 'INVALID_ARGUMENT',
+                'message' => 'The request contains invalid parameters or malformed data',
+                'details' => 'Invalid format for parameter "status": expected boolean'
+            ];
+            $response->getBody()->write(json_encode($errorData));
+            return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
+        }
+
         $lampUpdate = new LampUpdate();
         $lampUpdate->setData($data);
         $lamp = $this->repo->update($lampId, $lampUpdate);


### PR DESCRIPTION
This pull request strengthens the validation logic for the `createLamp` and `updateLamp` API endpoints in `DefaultApi.php`. The new checks ensure that incoming JSON requests are well-formed, strictly adhere to the expected schema, and provide clear error messages for invalid input. This improves API robustness and helps clients quickly identify issues with their requests.

**Request validation improvements:**

* Added explicit validation for JSON parsing errors, returning a 400 response with a descriptive error message if the request body is not valid JSON. [[1]](diffhunk://#diff-4273f33ae00ef1e93bf0f539f44a80b144410c03ff333b2806e4d62c5b62d447R27-R37) [[2]](diffhunk://#diff-4273f33ae00ef1e93bf0f539f44a80b144410c03ff333b2806e4d62c5b62d447R149-R227)
* Ensured that the request body must be a JSON object (associative array), not an indexed array, and returns an error if this is violated. [[1]](diffhunk://#diff-4273f33ae00ef1e93bf0f539f44a80b144410c03ff333b2806e4d62c5b62d447R48-R82) [[2]](diffhunk://#diff-4273f33ae00ef1e93bf0f539f44a80b144410c03ff333b2806e4d62c5b62d447R149-R227)

**Schema enforcement:**

* Added checks to reject requests with empty string field names or unknown fields, only allowing the `status` field as defined by the schema. [[1]](diffhunk://#diff-4273f33ae00ef1e93bf0f539f44a80b144410c03ff333b2806e4d62c5b62d447R48-R82) [[2]](diffhunk://#diff-4273f33ae00ef1e93bf0f539f44a80b144410c03ff333b2806e4d62c5b62d447R149-R227)
* For `updateLamp`, added validation to ensure the `status` field is present and is of boolean type, with clear error responses for missing or incorrectly typed fields.…on and update