### PR TITLE
Update .NET SDK version to 8.0.100 in global.json

### DIFF
--- a/src/csharp/LampControlApi/global.json
+++ b/src/csharp/LampControlApi/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "8.0.100",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
Bumps the .NET SDK version from 8.0.0 to 8.0.100 to ensure compatibility with the latest features and improvements.