### PR TITLE
Add Cloud Run deployment config for PHP API

### DIFF
--- a/src/php/README.md
+++ b/src/php/README.md
@@ -1,17 +1,59 @@
 # PHP Implementation
 
-This directory contains the PHP implementation of the Lamp Control API.
+This directory contains the PHP implementation of the Lamp Control API using Slim 4 framework.
 
 ## Features
 
-- REST API (Laravel/Symfony with OpenAPI 3.0)
-- GraphQL (Lighthouse)
-- gRPC
+- REST API with OpenAPI 3.0 specification
+- PHP 8.1+ with Slim 4 framework
+- PSR-7 HTTP message interface
+- PHP-DI dependency injection container
 - Database support for MySQL, PostgreSQL, and MongoDB
 
 ## Getting Started
 
-*Instructions will be added as implementation progresses*
+### Local Development
+
+```bash
+cd lamp-control-api
+composer install
+composer start
+```
+
+The API will be available at `http://localhost:8080`
+
+### Deployment to Google Cloud Run with Buildpacks
+
+The PHP application is configured to deploy to Google Cloud Run using buildpacks. The necessary files in `lamp-control-api/`:
+
+- `Procfile`: Specifies how to start the web server with nginx
+- `nginx.conf`: Nginx configuration for routing
+- `composer.json`: Project dependencies and configuration
+- `.gcloudignore`: Files to exclude from deployment
+
+Deploy with Cloud Build (from repo root):
+
+```bash
+# Cloud Build will use --path=src/php/lamp-control-api
+gcloud builds submit
+```
+
+Or deploy directly:
+
+```bash
+# From the lamp-control-api directory
+cd lamp-control-api
+gcloud run deploy php-lamp-control-api \
+  --source . \
+  --region europe-west1 \
+  --allow-unauthenticated
+```
+
+The buildpack will:
+1. Detect the PHP project via composer.json
+2. Install dependencies with `composer install --no-dev`
+3. Configure nginx with the custom config
+4. Serve the application from public/
 
 ## Directory Structure
 

--- a/src/php/lamp-control-api/.gcloudignore
+++ b/src/php/lamp-control-api/.gcloudignore
@@ -1,0 +1,37 @@
+# This file specifies files that should be ignored when deploying to Google Cloud
+
+# Git files
+.git
+.gitignore
+
+# CI/CD
+.github/
+
+# IDEs
+.vscode/
+.idea/
+
+# Tests
+tests/
+phpunit.xml
+phpunit.xml.dist
+
+# Coverage
+coverage/
+coverage.xml
+.phpunit.result.cache
+
+# Development files
+.php-cs-fixer.cache
+phpcs.xml.dist
+phpstan.neon.dist
+
+# Logs
+logs/
+
+# OpenAPI generator files
+.openapi-generator/
+.openapi-generator-ignore
+
+# Documentation (keeping essential files)
+COVERAGE.md

--- a/src/php/lamp-control-api/Procfile
+++ b/src/php/lamp-control-api/Procfile
@@ -1,0 +1,1 @@
+web: composer start

--- a/src/php/lamp-control-api/nginx.conf
+++ b/src/php/lamp-control-api/nginx.conf
@@ -1,0 +1,3 @@
+location / {
+    try_files $uri $uri/ /index.php?$query_string;
+}


### PR DESCRIPTION
Updated README with Slim 4 and Cloud Run deployment instructions. Added .gcloudignore, Procfile, and nginx.conf to support Google Cloud Buildpacks deployment for the lamp-control-api.