### PR TITLE
Update nginx.conf for PHP support and public root

### DIFF
--- a/src/php/lamp-control-api/nginx.conf
+++ b/src/php/lamp-control-api/nginx.conf
@@ -1,3 +1,13 @@
+root /workspace/public;
+index index.php;
+
 location / {
     try_files $uri $uri/ /index.php?$query_string;
+}
+
+location ~ \.php$ {
+    fastcgi_pass unix:/tmp/php-fpm.sock;
+    fastcgi_index index.php;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    include fastcgi_params;
 }


### PR DESCRIPTION
Set the root to /workspace/public and index to index.php. Added PHP location block to handle PHP files via php-fpm using a Unix socket.