### PR TITLE
Remove Procfile from lamp-control-api

### DIFF
--- a/src/php/lamp-control-api/Procfile
+++ b/src/php/lamp-control-api/Procfile
@@ -1,1 +1,0 @@
-web: composer start


### PR DESCRIPTION
Deleted the Procfile from src/php/lamp-control-api, which previously defined the web process for running 'composer start'.