### PR TITLE
Remove nginx config and project.toml from lamp-control-api

### DIFF
--- a/src/php/lamp-control-api/nginx.conf
+++ b/src/php/lamp-control-api/nginx.conf
@@ -1,0 +1,21 @@
+http {
+    server {
+        listen 8080;
+        server_name _;
+        
+        root /workspace/public;
+        index index.php index.html;
+
+        location / {
+            # try to serve file directly, fallback to index.php
+            try_files $uri /index.php$is_args$args;
+        }
+
+        location ~ \.php$ {
+            fastcgi_pass 127.0.0.1:9000;
+            fastcgi_index index.php;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            include fastcgi_params;
+        }
+    }
+}

--- a/src/php/lamp-control-api/project.toml
+++ b/src/php/lamp-control-api/project.toml
@@ -1,3 +1,7 @@
 [[build.env]]
 name = "BP_PHP_WEB_DIR"
 value = "public"
+
+[[build.env]]
+name = "NGINX_CONF_OVERRIDE"
+value = "nginx.conf"


### PR DESCRIPTION
Deleted nginx.conf and project.toml files from src/php/lamp-control-api, likely as part of a cleanup or migration away from custom Nginx configuration and related build environment settings.