### PR TITLE
Add Flyway database migrations to Kotlin implementation

### DIFF
--- a/src/kotlin/MIGRATIONS.md
+++ b/src/kotlin/MIGRATIONS.md
@@ -1,0 +1,89 @@
+# Database Migrations for Kotlin Implementation
+
+This Kotlin implementation uses **Flyway** for automated database schema migrations.
+
+## Overview
+
+Flyway is a database migration tool that applies versioned SQL migrations to your PostgreSQL database automatically on application startup.
+
+## Migration Files
+
+Migrations are located in `src/main/resources/db/migration/` and follow Flyway's naming convention:
+
+- `V1__Initial_schema.sql` - Creates the base `lamps` table with UUID, status, and timestamp columns
+- `V2__Add_soft_deletes.sql` - Adds the `deleted_at` column for soft delete functionality
+- `V3__Add_updated_at_trigger.sql` - Creates PostgreSQL trigger for automatic `updated_at` management
+
+## How It Works
+
+1. **On Application Startup**: `DatabaseFactory.init()` calls `FlywayConfig.runMigrations()`
+2. **Flyway Checks**: Flyway compares applied migrations (tracked in `flyway_schema_history` table) with available migration files
+3. **Apply Pending Migrations**: Any new migrations are executed in order
+4. **Validation**: Flyway validates that applied migrations haven't been modified
+
+## Configuration
+
+Flyway is configured in `FlywayConfig.kt` with the following settings:
+
+- **Locations**: `classpath:db/migration`
+- **Baseline on Migrate**: `true` (allows Flyway to baseline existing databases)
+- **Validate on Migrate**: `true` (validates migration checksums)
+
+## Dependencies
+
+Added to `build.gradle.kts`:
+
+```kotlin
+implementation("org.flywaydb:flyway-core:10.21.0")
+implementation("org.flywaydb:flyway-database-postgresql:10.21.0")
+```
+
+## Creating New Migrations
+
+To create a new migration:
+
+1. Create a new SQL file in `src/main/resources/db/migration/`
+2. Follow naming convention: `V<VERSION>__<Description>.sql`
+   - Example: `V4__Add_user_table.sql`
+3. Write your SQL migration
+4. Restart the application - Flyway will detect and apply it automatically
+
+## Migration Execution Order
+
+Migrations are applied in version order:
+1. V1 → V2 → V3 → ... → Vn
+
+## Rollback
+
+Flyway Community Edition (which we use) does not support automatic rollbacks. To rollback:
+
+1. Create a new migration that reverses the changes
+2. Or manually revert the database and remove the migration entry from `flyway_schema_history`
+
+## Troubleshooting
+
+### Migration Failed
+
+If a migration fails:
+- Check logs for the specific error
+- Fix the SQL in the migration file
+- Manually clean up any partial changes in the database
+- Delete the failed migration record from `flyway_schema_history` table
+- Restart the application
+
+### Checksum Mismatch
+
+If you see checksum validation errors:
+- This means a migration file was modified after being applied
+- **Never modify applied migrations** - create a new migration instead
+- To resolve: `flyway repair` (requires Flyway CLI) or manually update the checksum in `flyway_schema_history`
+
+## Comparison with Other Implementations
+
+- **Java**: Also uses Flyway (Spring Boot auto-configuration)
+- **Python**: Uses Alembic (Python-specific migration tool)
+- **TypeScript**: Uses Prisma Migrate (schema-first approach)
+- **C#**: Uses Entity Framework Migrations (code-first approach)
+- **Go**: Manual migrations (shared schema file)
+
+With this Flyway integration, Kotlin now has the same automated migration capabilities as Java!

--- a/src/kotlin/build.gradle.kts
+++ b/src/kotlin/build.gradle.kts
@@ -51,6 +51,10 @@ dependencies {
     implementation("org.postgresql:postgresql:42.7.4")
     implementation("com.zaxxer:HikariCP:5.1.0")
 
+    // Flyway for database migrations
+    implementation("org.flywaydb:flyway-core:10.21.0")
+    implementation("org.flywaydb:flyway-database-postgresql:10.21.0")
+
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
     testImplementation("io.ktor:ktor-server-test-host")
     testImplementation("org.junit.jupiter:junit-jupiter:5.9.3")

--- a/src/kotlin/src/main/kotlin/com/lampcontrol/database/DatabaseFactory.kt
+++ b/src/kotlin/src/main/kotlin/com/lampcontrol/database/DatabaseFactory.kt
@@ -23,6 +23,13 @@ object DatabaseFactory {
             return null
         }
 
+        // Run database migrations before initializing connection pool
+        val migrationSuccess = FlywayConfig.runMigrations(config)
+        if (!migrationSuccess) {
+            logger.error("Database migrations failed. Database connection will not be initialized.")
+            return null
+        }
+
         val hikariConfig = HikariConfig().apply {
             jdbcUrl = config.connectionString()
             driverClassName = "org.postgresql.Driver"

--- a/src/kotlin/src/main/kotlin/com/lampcontrol/database/FlywayConfig.kt
+++ b/src/kotlin/src/main/kotlin/com/lampcontrol/database/FlywayConfig.kt
@@ -1,0 +1,57 @@
+package com.lampcontrol.database
+
+import com.zaxxer.hikari.HikariDataSource
+import org.flywaydb.core.Flyway
+import org.slf4j.LoggerFactory
+
+/**
+ * Flyway configuration for database migrations
+ */
+object FlywayConfig {
+    private val logger = LoggerFactory.getLogger(FlywayConfig::class.java)
+
+    /**
+     * Run database migrations using Flyway.
+     * Should be called before initializing the database connection.
+     *
+     * @param config Database configuration
+     * @return true if migrations were successful or skipped, false if migrations failed
+     */
+    fun runMigrations(config: DatabaseConfig): Boolean {
+        return try {
+            logger.info("Starting database migrations with Flyway")
+
+            val flyway = Flyway.configure()
+                .dataSource(
+                    config.connectionString(),
+                    config.user,
+                    config.password
+                )
+                .locations("classpath:db/migration")
+                .baselineOnMigrate(true)
+                .baselineVersion("0")
+                .validateOnMigrate(true)
+                .load()
+
+            val migrationsExecuted = flyway.migrate()
+
+            if (migrationsExecuted.migrationsExecuted > 0) {
+                logger.info(
+                    "Successfully executed {} migration(s). Current schema version: {}",
+                    migrationsExecuted.migrationsExecuted,
+                    migrationsExecuted.targetSchemaVersion
+                )
+            } else {
+                logger.info(
+                    "Database schema is up to date at version: {}",
+                    flyway.info().current()?.version ?: "baseline"
+                )
+            }
+
+            true
+        } catch (e: Exception) {
+            logger.error("Failed to run database migrations", e)
+            false
+        }
+    }
+}

--- a/src/kotlin/src/main/resources/db/migration/V1__Initial_schema.sql
+++ b/src/kotlin/src/main/resources/db/migration/V1__Initial_schema.sql
@@ -1,0 +1,24 @@
+-- PostgreSQL Schema for Lamp Control API
+-- Version: 1.0.0
+
+-- Enable UUID extension
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- Lamps table
+CREATE TABLE IF NOT EXISTS lamps (
+    id UUID PRIMARY KEY DEFAULT UUID_GENERATE_V4(),
+    is_on BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Add table comments
+COMMENT ON TABLE lamps IS 'Stores lamp entities and their current status';
+COMMENT ON COLUMN lamps.id IS 'Unique identifier for the lamp';
+COMMENT ON COLUMN lamps.is_on IS 'Current status of the lamp (true = ON, false = OFF)';
+COMMENT ON COLUMN lamps.created_at IS 'Timestamp when the lamp was created';
+COMMENT ON COLUMN lamps.updated_at IS 'Timestamp when the lamp was last updated';
+
+-- Create indexes
+CREATE INDEX IF NOT EXISTS idx_lamps_is_on ON lamps (is_on);
+CREATE INDEX IF NOT EXISTS idx_lamps_created_at ON lamps (created_at);

--- a/src/kotlin/src/main/resources/db/migration/V2__Add_soft_deletes.sql
+++ b/src/kotlin/src/main/resources/db/migration/V2__Add_soft_deletes.sql
@@ -1,0 +1,12 @@
+-- Add soft delete support to lamps table
+-- Version: 2.0.0
+
+-- Add deleted_at column for soft deletes
+ALTER TABLE lamps
+ADD COLUMN deleted_at TIMESTAMP WITH TIME ZONE;
+
+-- Add index on deleted_at for query performance
+CREATE INDEX idx_lamps_deleted_at ON lamps (deleted_at);
+
+-- Add comment for deleted_at column
+COMMENT ON COLUMN lamps.deleted_at IS 'Timestamp when the lamp was soft deleted, NULL if active';

--- a/src/kotlin/src/main/resources/db/migration/V3__Add_updated_at_trigger.sql
+++ b/src/kotlin/src/main/resources/db/migration/V3__Add_updated_at_trigger.sql
@@ -1,0 +1,20 @@
+-- Add automatic updated_at trigger
+-- Version: 3.0.0
+
+-- Create updated_at trigger function
+CREATE OR REPLACE FUNCTION UPDATE_UPDATED_AT_COLUMN()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create trigger on lamps table
+CREATE TRIGGER update_lamps_updated_at
+BEFORE UPDATE ON lamps
+FOR EACH ROW
+EXECUTE FUNCTION UPDATE_UPDATED_AT_COLUMN();
+
+-- Update comment for updated_at column
+COMMENT ON COLUMN lamps.updated_at IS 'Timestamp when the lamp was last updated (automatically managed by database trigger)';


### PR DESCRIPTION
Add automated database migration support using Flyway to the Kotlin/Ktor implementation, bringing it to feature parity with the Java implementation.

Changes:
- Add Flyway dependencies (flyway-core and flyway-database-postgresql)
- Create FlywayConfig for migration management on application startup
- Add three versioned migrations:
  * V1__Initial_schema.sql: Creates base lamps table
  * V2__Add_soft_deletes.sql: Adds deleted_at column
  * V3__Add_updated_at_trigger.sql: Adds PostgreSQL trigger for updated_at
- Integrate migration runner into DatabaseFactory.init()
- Add MIGRATIONS.md documentation

The migrations are applied automatically on application startup before initializing the database connection pool. Failed migrations prevent application startup to ensure database consistency.