### PR TITLE
Fix C# mode testing by adding ConnectionStrings__LampControl env var

### DIFF
--- a/.github/workflows/csharp-ci.yml
+++ b/.github/workflows/csharp-ci.yml
@@ -262,7 +262,6 @@ jobs:
     name: Mode Testing
     runs-on: ubuntu-latest
     needs: [code-quality]
-    if: false  # TODO: Re-enable after fixing C# migration issues (see issue #272)
 
     strategy:
       matrix:
@@ -304,8 +303,7 @@ jobs:
         run: dotnet restore --locked-mode
 
       - name: Test all operation modes
-        env:
-          ConnectionStrings__LampControl: Host=localhost;Port=5432;Database=lampcontrol;Username=test;Password=test
+        # ConnectionStrings__LampControl is set dynamically by test-modes.sh for each database
         run: |
           ../../scripts/ci/test-modes.sh \
             "csharp" \

--- a/scripts/ci/test-modes.sh
+++ b/scripts/ci/test-modes.sh
@@ -95,6 +95,9 @@ test_migrate_mode() {
     export SPRING_DATASOURCE_URL="jdbc:postgresql://$POSTGRES_HOST:$POSTGRES_PORT/lampcontrol_prod?sslmode=disable"
     export FLYWAY_ENABLED="true"
 
+    # C# specific variables (Npgsql connection string format)
+    export ConnectionStrings__LampControl="Host=$POSTGRES_HOST;Port=$POSTGRES_PORT;Database=lampcontrol_prod;Username=$POSTGRES_USER;Password=$POSTGRES_PASSWORD"
+
     # Run migrations
     log_info "Running: $migrate_cmd"
     if eval "$migrate_cmd"; then
@@ -141,6 +144,9 @@ test_serve_only_mode() {
     # Spring Boot specific variables (Java)
     export SPRING_DATASOURCE_URL="jdbc:postgresql://$POSTGRES_HOST:$POSTGRES_PORT/lampcontrol_prod?sslmode=disable"
     export FLYWAY_ENABLED="true"
+
+    # C# specific variables (Npgsql connection string format)
+    export ConnectionStrings__LampControl="Host=$POSTGRES_HOST;Port=$POSTGRES_PORT;Database=lampcontrol_prod;Username=$POSTGRES_USER;Password=$POSTGRES_PASSWORD"
 
     # Start server in background
     log_info "Starting server: $serve_only_cmd"
@@ -233,6 +239,9 @@ test_serve_mode() {
     # Spring Boot specific variables (Java)
     export SPRING_DATASOURCE_URL="jdbc:postgresql://$POSTGRES_HOST:$POSTGRES_PORT/lampcontrol_serve?sslmode=disable"
     export FLYWAY_ENABLED="true"
+
+    # C# specific variables (Npgsql connection string format)
+    export ConnectionStrings__LampControl="Host=$POSTGRES_HOST;Port=$POSTGRES_PORT;Database=lampcontrol_serve;Username=$POSTGRES_USER;Password=$POSTGRES_PASSWORD"
 
     # Start server in background
     log_info "Starting server with migrations: $serve_cmd"


### PR DESCRIPTION
## Summary
- Adds `ConnectionStrings__LampControl` environment variable to `test-modes.sh` for C# compatibility
- Re-enables mode testing in C# CI workflow
- Removes hardcoded connection string from CI (now set dynamically by test script)

## Test plan
- [ ] CI mode testing passes for C#
- [ ] Migrate mode creates `lamps` table in `lampcontrol_prod`
- [ ] Serve-only mode uses existing schema
- [ ] Serve mode creates `lamps` table in `lampcontrol_serve`

Fixes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)