### PR TITLE
Fix Java mode testing by fixing conditional bean configuration

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -83,7 +83,6 @@ jobs:
     name: Mode Testing
     runs-on: ubuntu-latest
     needs: [code-quality]
-    if: false  # TODO: Re-enable after fixing Java mode testing issues (see issue #273)
 
     strategy:
       matrix:

--- a/src/java/src/main/java/org/openapitools/config/DataSourceConfig.java
+++ b/src/java/src/main/java/org/openapitools/config/DataSourceConfig.java
@@ -35,14 +35,13 @@ public class DataSourceConfig {
   private String driverClassName;
 
   /**
-   * Creates a HikariCP DataSource bean configured from application.properties.
+   * Creates a HikariConfig bean configured from application.properties.
    *
-   * @return configured DataSource using HikariCP connection pooling
+   * @return configured HikariConfig with core JDBC properties and hikari-specific settings
    */
   @Bean
   @ConfigurationProperties(prefix = "spring.datasource.hikari")
-  public DataSource dataSource() {
-    // HikariConfig will be populated from spring.datasource.hikari.* properties
+  public HikariConfig hikariConfig() {
     HikariConfig config = new HikariConfig();
 
     // Set core JDBC properties
@@ -51,6 +50,17 @@ public class DataSourceConfig {
     config.setPassword(password);
     config.setDriverClassName(driverClassName);
 
-    return new HikariDataSource(config);
+    return config;
+  }
+
+  /**
+   * Creates a HikariCP DataSource bean from the configured HikariConfig.
+   *
+   * @param hikariConfig the HikariConfig bean with all properties already applied
+   * @return configured DataSource using HikariCP connection pooling
+   */
+  @Bean
+  public DataSource dataSource(HikariConfig hikariConfig) {
+    return new HikariDataSource(hikariConfig);
   }
 }

--- a/src/java/src/main/java/org/openapitools/config/JpaConfig.java
+++ b/src/java/src/main/java/org/openapitools/config/JpaConfig.java
@@ -3,8 +3,8 @@ package org.openapitools.config;
 import java.util.Properties;
 import javax.sql.DataSource;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.orm.jpa.JpaTransactionManager;
@@ -20,7 +20,7 @@ import org.springframework.transaction.PlatformTransactionManager;
  * application uses an in-memory repository.
  */
 @Configuration
-@ConditionalOnBean(DataSource.class)
+@Conditional(OnDatabaseUrlCondition.class)
 @EnableJpaRepositories(basePackages = "org.openapitools.repository")
 public class JpaConfig {
 

--- a/src/java/src/main/java/org/openapitools/config/RepositoryConfig.java
+++ b/src/java/src/main/java/org/openapitools/config/RepositoryConfig.java
@@ -6,8 +6,8 @@ import java.util.UUID;
 import org.openapitools.entity.LampEntity;
 import org.openapitools.repository.JpaLampRepository;
 import org.openapitools.repository.LampRepository;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.domain.Page;
@@ -33,7 +33,7 @@ public class RepositoryConfig {
    */
   @Bean
   @Primary
-  @ConditionalOnBean(JpaLampRepository.class)
+  @Conditional(OnDatabaseUrlCondition.class)
   public LampRepository lampRepository(final JpaLampRepository jpaRepository) {
     return new LampRepository() {
       @Override

--- a/src/java/src/main/java/org/openapitools/repository/JpaLampRepository.java
+++ b/src/java/src/main/java/org/openapitools/repository/JpaLampRepository.java
@@ -2,9 +2,7 @@ package org.openapitools.repository;
 
 import java.util.List;
 import java.util.UUID;
-import org.openapitools.config.OnDatabaseUrlCondition;
 import org.openapitools.entity.LampEntity;
-import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -27,7 +25,6 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 @Primary
-@Conditional(OnDatabaseUrlCondition.class)
 public interface JpaLampRepository extends JpaRepository<LampEntity, UUID> {
 
   /**


### PR DESCRIPTION
## Summary
- Fixes Spring conditional bean configuration to ensure LampRepository is always created
- Changes JpaConfig from `@ConditionalOnBean(DataSource.class)` to `@Conditional(OnDatabaseUrlCondition.class)` for environment-based evaluation
- Removes ineffective `@Conditional` from JpaLampRepository interface (Spring Data JPA ignores it)
- Changes InMemoryLampRepository to use `@ConditionalOnMissingBean` as a fallback pattern
- Deletes unused OnNoDatabaseUrlCondition class
- Re-enables mode testing in CI workflow

Fixes #273

## Test plan
- [ ] CI mode testing passes (migrate, serve-only, serve modes)
- [ ] Application starts with in-memory repository when no database configured
- [ ] Application starts with JPA repository when SPRING_DATASOURCE_URL is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)