### PR TITLE
fix(python): enable mode-testing in CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -103,8 +103,6 @@ jobs:
 
   mode-testing:
     name: Mode Testing
-    # Temporarily disabled due to race condition - see #285
-    if: false
     runs-on: ubuntu-latest
     needs: [test]
 
@@ -167,11 +165,11 @@ jobs:
           ../../scripts/ci/test-modes.sh \
             "python" \
             "poetry install --no-interaction" \
-            "poetry run python -m openapi_server.cli --mode=migrate" \
-            "poetry run python -m openapi_server.cli --mode=serve-only --port=8000" \
-            "poetry run python -m openapi_server.cli --mode=serve --port=8000" \
+            "poetry run python -m src.openapi_server.cli --mode=migrate" \
+            "poetry run python -m src.openapi_server.cli --mode=serve-only --port=8000" \
+            "poetry run python -m src.openapi_server.cli --mode=serve --port=8001" \
             8000 \
-            8000
+            8001
 
   schemathesis-testing:
     name: Schemathesis API Testing


### PR DESCRIPTION
## Summary
- Re-enable the `mode-testing` job in Python CI that was disabled due to a race condition (#285)
- Fix port collision: use separate ports for `serve-only` (8000) and `serve` (8001) modes to prevent the race condition where the old server process hadn't fully released the port
- Fix module path from `openapi_server.cli` to `src.openapi_server.cli` to match the project's `src` layout (dependencies installed with `--no-root`)

## Test plan
- [ ] CI `mode-testing` job passes: migrate mode runs Alembic migrations, serve-only starts without migrations, serve runs migrations then starts
- [ ] Existing `test` and `schemathesis-testing` jobs remain unaffected
- [ ] Verified locally that `poetry run python -m src.openapi_server.cli --help` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)