### PR TITLE
ci(python): enforce 80% minimum code coverage

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -90,7 +90,7 @@ jobs:
         MYSQL_DATABASE: lamp_test
         MONGODB_URI: mongodb://localhost:27017/lamp_test
       run: |
-        poetry run pytest --cov=src --cov-report=json:coverage/coverage.json
+        poetry run pytest --cov=src --cov-report=json:coverage/coverage.json --cov-fail-under=80
 
     - name: Commit coverage summary
       if: github.event_name == 'workflow_dispatch'

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -111,7 +111,7 @@ skip_gitignore = true
 
 [tool.pytest.ini_options]
 minversion = "8.0"
-addopts = "-ra -q --cov=src --cov-report=term-missing --cov-report=json:coverage/coverage.json"
+addopts = "-ra -q --cov=src --cov-report=term-missing --cov-report=json:coverage/coverage.json --cov-fail-under=80"
 python_files = ["test_*.py", "*_test.py"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"


### PR DESCRIPTION
## Summary
- Add `--cov-fail-under=80` to pytest options in `pyproject.toml` so local test runs fail if coverage drops below 80%
- Add `--cov-fail-under=80` to the CI workflow (`python-ci.yml`) so PR builds also enforce the threshold

## Test plan
- [ ] Run `cd src/python && poetry run pytest` locally and verify it reports the coverage threshold
- [ ] Confirm CI pipeline fails if coverage is below 80%

🤖 Generated with [Claude Code](https://claude.com/claude-code)