### PR TITLE
fix(java): exclude entry point and config classes from JaCoCo coverage

### DIFF
--- a/src/java/pom.xml
+++ b/src/java/pom.xml
@@ -281,6 +281,11 @@
                     <excludes>
                         <exclude>**/org/openapitools/api/**</exclude>
                         <exclude>**/org/openapitools/model/**</exclude>
+                        <exclude>**/OpenApiGeneratorApplication*</exclude>
+                        <exclude>**/ApplicationMode*</exclude>
+                        <exclude>**/config/FlywayConfig*</exclude>
+                        <exclude>**/config/DataSourceConfig*</exclude>
+                        <exclude>**/config/JpaConfig*</exclude>
                     </excludes>
                 </configuration>
                 <executions>


### PR DESCRIPTION
## Summary
- Exclude `OpenApiGeneratorApplication`, `ApplicationMode`, and Spring config classes (`FlywayConfig`, `DataSourceConfig`, `JpaConfig`) from JaCoCo coverage measurement
- Aligns Java coverage reporting with C#, Go, and Kotlin which already exclude equivalent bootstrap/config files
- These classes account for ~46 missed lines that unfairly drag down overall coverage

## Test plan
- [ ] Verify CI passes with updated JaCoCo exclusions
- [ ] Confirm coverage percentage increases to a comparable level with other languages

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)