### PR TITLE
fix(python): exclude entry point files from coverage measurement

### DIFF
--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -110,6 +110,12 @@ skip = [
 ]
 skip_gitignore = true
 
+[tool.coverage.run]
+omit = [
+    "src/openapi_server/main.py",
+    "src/openapi_server/cli.py",
+]
+
 [tool.pytest.ini_options]
 minversion = "8.0"
 addopts = "-ra -q --cov=src --cov-report=term-missing --cov-report=json:coverage/coverage.json --cov-fail-under=80"


### PR DESCRIPTION
## Summary
- Adds `[tool.coverage.run]` section to `pyproject.toml` to exclude `main.py` and `cli.py` from coverage measurement
- Normalizes Python coverage reporting to match C#, Go, and Kotlin which already exclude their entry point files
- Coverage still meets the 80% threshold after the change

## Test plan
- [x] Verified `poetry run pytest` passes with the updated config (117 passed, integration tests skipped without Docker)
- [x] Confirmed `main.py` and `cli.py` no longer appear in coverage report
- [x] Coverage remains above 80% minimum (82.96%)

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)