### PR TITLE
fix(java): use line coverage instead of instruction coverage

### DIFF
--- a/src/java/pom.xml
+++ b/src/java/pom.xml
@@ -315,7 +315,7 @@
                                     <element>BUNDLE</element>
                                     <limits>
                                         <limit>
-                                            <counter>INSTRUCTION</counter>
+                                            <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
                                             <minimum>0.80</minimum>
                                         </limit>


### PR DESCRIPTION
## Summary
- Switch JaCoCo `jacocoTestCoverageVerification` counter from `INSTRUCTION` to `LINE` in `pom.xml`
- Aligns Java's CI coverage threshold with all other languages (TypeScript, Python, Go, C#, Kotlin) which all report line coverage
- No other changes needed — `extract-coverage.sh` already extracts line coverage from JaCoCo XML for the comparison table

## Test plan
- [ ] CI passes with `LINE` counter threshold at 80%
- [ ] `mvn test jacoco:report jacoco:check` succeeds
- [ ] Coverage percentage in comparison table remains consistent (extracted via `extract-coverage.sh`)

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)