### PR TITLE
fix(python): exclude generated Pydantic models from coverage measurement

### DIFF
--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -115,6 +115,8 @@ omit = [
     "src/openapi_server/main.py",
     "src/openapi_server/cli.py",
     "src/openapi_server/test/*",
+    "src/openapi_server/models/*",
+    "src/openapi_server/apis/default_api_base.py",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary
- Exclude generated Pydantic model files (`src/openapi_server/models/*`) and generated API base file (`default_api_base.py`) from Python coverage measurement
- Aligns Python coverage reporting with Java, Kotlin, and TypeScript, which already exclude their generated code

Closes #332

## Test plan
- [ ] Verify `poetry run pytest --cov` no longer reports coverage for files in `models/` or `default_api_base.py`
- [ ] Confirm coverage percentage reflects only hand-written application code

🤖 Generated with [Claude Code](https://claude.com/claude-code)