### PR TITLE
ci: add release branch protection and CI triggers

### DIFF
--- a/.github/workflows/csharp-ci.yml
+++ b/.github/workflows/csharp-ci.yml
@@ -2,12 +2,12 @@ name: C# CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop, 'release-*' ]
     paths:
       - 'src/csharp/**'
       - '.github/workflows/csharp-ci.yml'
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, develop, 'release-*' ]
     paths:
       - 'src/csharp/**'
       - '.github/workflows/csharp-ci.yml'

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -2,12 +2,12 @@ name: Go CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, 'release-*']
     paths:
       - 'src/go/**'
       - '.github/workflows/go-ci.yml'
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, 'release-*']
     paths:
       - 'src/go/**'
       - '.github/workflows/go-ci.yml'

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -2,12 +2,12 @@ name: Java CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop, 'release-*' ]
     paths:
       - 'src/java/**'
       - '.github/workflows/java-ci.yml'
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, develop, 'release-*' ]
     paths:
       - 'src/java/**'
       - '.github/workflows/java-ci.yml'

--- a/.github/workflows/kotlin-ci.yml
+++ b/.github/workflows/kotlin-ci.yml
@@ -2,12 +2,12 @@ name: Kotlin CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop, 'release-*' ]
     paths:
       - 'src/kotlin/**'
       - '.github/workflows/kotlin-ci.yml'
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, develop, 'release-*' ]
     paths:
       - 'src/kotlin/**'
       - '.github/workflows/kotlin-ci.yml'

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -2,12 +2,12 @@ name: Python CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop, 'release-*' ]
     paths:
       - 'src/python/**'
       - '.github/workflows/python-ci.yml'
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, develop, 'release-*' ]
     paths:
       - 'src/python/**'
       - '.github/workflows/python-ci.yml'

--- a/.github/workflows/sql-ci.yml
+++ b/.github/workflows/sql-ci.yml
@@ -2,13 +2,13 @@ name: SQL CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop, 'release-*' ]
     paths:
       - 'database/sql/**'
       - '.sqlfluff'
       - '.github/workflows/sql-ci.yml'
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, develop, 'release-*' ]
     paths:
       - 'database/sql/**'
       - '.sqlfluff'

--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -2,12 +2,12 @@ name: TypeScript CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop, 'release-*' ]
     paths:
       - 'src/typescript/**'
       - '.github/workflows/typescript-ci.yml'
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, develop, 'release-*' ]
     paths:
       - 'src/typescript/**'
       - '.github/workflows/typescript-ci.yml'


### PR DESCRIPTION
## Summary
- Created a GitHub ruleset ("release branches") to protect all `release-*` branches with the same rules as `main` (PRs required, squash merge only, no force push/deletion, linear history, Copilot review)
- Updated all 7 CI workflows to trigger on `release-*` branches so patch fix PRs get full CI coverage

## Test plan
- [x] Verify ruleset is active: `gh api repos/davideme/lamp-control-api-reference/rulesets`
- [ ] Confirm a PR to `release-1.0.x` triggers CI workflows
- [ ] Verify direct push to `release-1.0.x` is blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)