### PR TITLE
refactor(go): improve idiomatic Go patterns

### DIFF
--- a/src/go/api/lamp_mapper.go
+++ b/src/go/api/lamp_mapper.go
@@ -6,18 +6,8 @@ import (
 	"github.com/davideme/lamp-control-api-reference/api/entities"
 )
 
-// LampMapper handles conversion between domain entities and API models.
-// This separation allows the internal domain model to evolve independently
-// from the external API contract.
-type LampMapper struct{}
-
-// NewLampMapper creates a new instance of LampMapper
-func NewLampMapper() *LampMapper {
-	return &LampMapper{}
-}
-
 // ToAPIModel converts from domain entity to API model
-func (m *LampMapper) ToAPIModel(entity *entities.LampEntity) Lamp {
+func ToAPIModel(entity *entities.LampEntity) Lamp {
 	return Lamp{
 		Id:        entity.ID,
 		Status:    entity.Status,
@@ -27,7 +17,7 @@ func (m *LampMapper) ToAPIModel(entity *entities.LampEntity) Lamp {
 }
 
 // ToEntity converts from API model to domain entity
-func (m *LampMapper) ToEntity(apiModel Lamp) *entities.LampEntity {
+func ToEntity(apiModel Lamp) *entities.LampEntity {
 	return &entities.LampEntity{
 		ID:        apiModel.Id,
 		Status:    apiModel.Status,
@@ -37,12 +27,12 @@ func (m *LampMapper) ToEntity(apiModel Lamp) *entities.LampEntity {
 }
 
 // CreateEntityFromAPICreate converts from API create model to domain entity
-func (m *LampMapper) CreateEntityFromAPICreate(createModel LampCreate) *entities.LampEntity {
+func CreateEntityFromAPICreate(createModel LampCreate) *entities.LampEntity {
 	return entities.NewLampEntity(createModel.Status)
 }
 
 // UpdateEntityFromAPIUpdate creates a new domain entity with updated data from API update model
-func (m *LampMapper) UpdateEntityFromAPIUpdate(entity *entities.LampEntity, updateModel LampUpdate) *entities.LampEntity {
+func UpdateEntityFromAPIUpdate(entity *entities.LampEntity, updateModel LampUpdate) *entities.LampEntity {
 	// Create a new entity instead of modifying the original to avoid race conditions
 	updatedEntity := &entities.LampEntity{
 		ID:        entity.ID,

--- a/src/go/api/mock_repository_test.go
+++ b/src/go/api/mock_repository_test.go
@@ -70,11 +70,12 @@ func (mr *MockLampRepositoryMockRecorder) Delete(ctx, id any) *gomock.Call {
 }
 
 // Exists mocks base method.
-func (m *MockLampRepository) Exists(ctx context.Context, id string) bool {
+func (m *MockLampRepository) Exists(ctx context.Context, id string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Exists", ctx, id)
 	ret0, _ := ret[0].(bool)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Exists indicates an expected call of Exists.

--- a/src/go/api/postgres_repository.go
+++ b/src/go/api/postgres_repository.go
@@ -170,10 +170,17 @@ func (r *PostgresLampRepository) List(ctx context.Context) ([]*entities.LampEnti
 }
 
 // Exists checks if a lamp exists in the repository
-func (r *PostgresLampRepository) Exists(ctx context.Context, id string) bool {
+func (r *PostgresLampRepository) Exists(ctx context.Context, id string) (bool, error) {
 	_, err := r.GetByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, ErrLampNotFound) {
+			return false, nil
+		}
 
-	return err == nil
+		return false, fmt.Errorf("failed to check lamp existence: %w", err)
+	}
+
+	return true, nil
 }
 
 // convertToEntity converts a sqlc Lamp model to a domain LampEntity

--- a/src/go/api/postgres_repository_test.go
+++ b/src/go/api/postgres_repository_test.go
@@ -308,14 +308,20 @@ func testPostgresExists(t *testing.T, repo *PostgresLampRepository) {
 	defer repo.Delete(ctx, lampEntity.ID.String())
 
 	// Test that it exists
-	exists := repo.Exists(ctx, lampEntity.ID.String())
+	exists, err := repo.Exists(ctx, lampEntity.ID.String())
+	if err != nil {
+		t.Fatalf("Exists failed: %v", err)
+	}
 	if !exists {
 		t.Error("Expected lamp to exist")
 	}
 
 	// Test non-existent lamp
 	nonExistentID := uuid.New().String()
-	exists = repo.Exists(ctx, nonExistentID)
+	exists, err = repo.Exists(ctx, nonExistentID)
+	if err != nil {
+		t.Fatalf("Exists failed: %v", err)
+	}
 	if exists {
 		t.Error("Expected lamp to not exist")
 	}

--- a/src/go/api/repository.go
+++ b/src/go/api/repository.go
@@ -30,7 +30,7 @@ type LampRepository interface {
 	List(ctx context.Context) ([]*entities.LampEntity, error)
 
 	// Exists checks if a lamp exists in the repository
-	Exists(ctx context.Context, id string) bool
+	Exists(ctx context.Context, id string) (bool, error)
 }
 
 // InMemoryLampRepository implements LampRepository using an in-memory map
@@ -125,11 +125,11 @@ func (r *InMemoryLampRepository) List(ctx context.Context) ([]*entities.LampEnti
 }
 
 // Exists checks if a lamp exists in the repository
-func (r *InMemoryLampRepository) Exists(ctx context.Context, id string) bool {
+func (r *InMemoryLampRepository) Exists(ctx context.Context, id string) (bool, error) {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
 	_, exists := r.lamps[id]
 
-	return exists
+	return exists, nil
 }

--- a/src/go/api/repository_test.go
+++ b/src/go/api/repository_test.go
@@ -217,7 +217,10 @@ func TestInMemoryLampRepository_Delete(t *testing.T) {
 	}
 
 	// Verify lamp exists
-	exists := repo.Exists(ctx, lamp.ID.String())
+	exists, err := repo.Exists(ctx, lamp.ID.String())
+	if err != nil {
+		t.Fatalf("Exists failed: %v", err)
+	}
 	if !exists {
 		t.Error("Lamp should exist before deletion")
 	}
@@ -229,7 +232,10 @@ func TestInMemoryLampRepository_Delete(t *testing.T) {
 	}
 
 	// Verify lamp no longer exists
-	exists = repo.Exists(ctx, lamp.ID.String())
+	exists, err = repo.Exists(ctx, lamp.ID.String())
+	if err != nil {
+		t.Fatalf("Exists failed: %v", err)
+	}
 	if exists {
 		t.Error("Lamp should not exist after deletion")
 	}
@@ -333,19 +339,25 @@ func TestInMemoryLampRepository_Exists(t *testing.T) {
 	}
 
 	// Test non-existent lamp
-	exists := repo.Exists(ctx, lamp.ID.String())
+	exists, err := repo.Exists(ctx, lamp.ID.String())
+	if err != nil {
+		t.Fatalf("Exists failed: %v", err)
+	}
 	if exists {
 		t.Error("Exists should return false for non-existent lamp")
 	}
 
 	// Create lamp
-	err := repo.Create(ctx, lamp)
+	err = repo.Create(ctx, lamp)
 	if err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
 
 	// Test existing lamp
-	exists = repo.Exists(ctx, lamp.ID.String())
+	exists, err = repo.Exists(ctx, lamp.ID.String())
+	if err != nil {
+		t.Fatalf("Exists failed: %v", err)
+	}
 	if !exists {
 		t.Error("Exists should return true for existing lamp")
 	}
@@ -357,7 +369,10 @@ func TestInMemoryLampRepository_Exists(t *testing.T) {
 	}
 
 	// Test deleted lamp
-	exists = repo.Exists(ctx, lamp.ID.String())
+	exists, err = repo.Exists(ctx, lamp.ID.String())
+	if err != nil {
+		t.Fatalf("Exists failed: %v", err)
+	}
 	if exists {
 		t.Error("Exists should return false for deleted lamp")
 	}
@@ -464,7 +479,11 @@ func TestInMemoryLampRepository_ConcurrentReadWrite(t *testing.T) {
 
 				// Check if a specific lamp exists
 				lampId := initialLamps[j%len(initialLamps)].ID.String()
-				exists := repo.Exists(ctx, lampId)
+				exists, existsErr := repo.Exists(ctx, lampId)
+				if existsErr != nil {
+					t.Errorf("Exists failed for lamp %s: %v", lampId, existsErr)
+					return
+				}
 				if !exists {
 					t.Errorf("Expected lamp %s to exist", lampId)
 					return

--- a/src/go/integration_test.go
+++ b/src/go/integration_test.go
@@ -79,14 +79,11 @@ func TestDomainEntitySeparation(t *testing.T) {
 	// Create a domain entity
 	lampEntity := entities.NewLampEntity(true)
 
-	// Create a mapper
-	mapper := api.NewLampMapper()
-
 	// Convert entity to API model
-	apiModel := mapper.ToAPIModel(lampEntity)
+	apiModel := api.ToAPIModel(lampEntity)
 
 	// Convert API model back to entity
-	convertedEntity := mapper.ToEntity(apiModel)
+	convertedEntity := api.ToEntity(apiModel)
 
 	// Verify they have the same data
 	if lampEntity.ID != convertedEntity.ID {


### PR DESCRIPTION
## Summary
- **APIError now wraps original errors** — Added `Err` field and `Unwrap()` method so `errors.Is()`/`errors.As()` work through the error chain
- **Named `poolCloser` interface** — Replaced anonymous `interface{ Close() }` with a discoverable named interface (`io.Closer` doesn't fit since `pgxpool.Pool.Close()` returns no error)
- **Standalone mapper functions** — Removed stateless `LampMapper` struct; converted 4 methods to package-level functions (`ToAPIModel`, `ToEntity`, `CreateEntityFromAPICreate`, `UpdateEntityFromAPIUpdate`)
- **`Exists()` returns `(bool, error)`** — Interface and both implementations now surface DB errors instead of silently swallowing them; Postgres impl distinguishes "not found" from actual failures
- **Improved fallback logging** — Both in-memory fallback paths now log with `WARNING:` prefix and include the original error

Closes #354

## Test plan
- [x] All unit tests pass (`go test ./... -short`)
- [x] Linter passes (`make lint`) — 0 issues
- [x] Mock regenerated via `go generate` to match updated `Exists` signature
- [ ] CI passes (build, test, lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)