### PR TITLE
refactor(go): use Makefile coverage-check target in CI

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -87,40 +87,9 @@ jobs:
           go mod download
           go mod tidy
 
-      - name: Run tests
+      - name: Run tests and check coverage
         working-directory: src/go
-        run: go test -v -race -coverprofile=coverage.out ./...
-
-      - name: Check code coverage
-        working-directory: src/go
-        run: |
-          echo "Checking code coverage..."
-
-          # Filter out generated files and main packages from coverage
-          echo "Filtering out generated files from coverage calculation..."
-          grep -vE '(\.gen\.go:|/queries/|/main\.go:)' coverage.out > coverage.filtered.out || true
-
-          if [ -s coverage.filtered.out ]; then
-            mv coverage.filtered.out coverage.out
-          else
-            echo "⚠️  Warning: No non-generated/non-main files found"
-          fi
-
-          coverage=$(go tool cover -func=coverage.out | grep total: | \
-            awk '{print $3}' | sed 's/%//')
-          echo "Current coverage (excluding generated files): ${coverage}%"
-
-          # Check if coverage is at least 80%
-          meets_threshold=$(awk -v cov="$coverage" -v thresh="80" \
-            'BEGIN {print (cov >= thresh)}')
-
-          if [ "$meets_threshold" -eq 0 ]; then
-            echo "❌ Code coverage is ${coverage}%, below required 80%"
-            echo "Please add more tests to increase coverage."
-            exit 1
-          else
-            echo "✅ Code coverage is ${coverage}%, meets required 80%"
-          fi
+        run: make coverage-check
 
       - name: Generate coverage report
         working-directory: src/go

--- a/src/go/scripts/check-coverage.sh
+++ b/src/go/scripts/check-coverage.sh
@@ -21,9 +21,9 @@ if [ ! -f "$COVERAGE_FILE" ]; then
     exit 1
 fi
 
-# Filter out generated files from coverage (files ending with .gen.go)
-echo "Filtering out generated files from coverage calculation..."
-grep -v "\.gen\.go:" "$COVERAGE_FILE" > "${COVERAGE_FILE}.filtered" || true
+# Filter out generated files and query files from coverage
+echo "Filtering out generated files and queries from coverage calculation..."
+grep -vE '(\.gen\.go:|/queries/)' "$COVERAGE_FILE" > "${COVERAGE_FILE}.filtered" || true
 
 # Also filter out main functions/packages which are hard to unit test
 echo "Filtering out main packages from coverage calculation..."


### PR DESCRIPTION
## Summary
- Replaced inline coverage checking logic in `go-ci.yml` with `make coverage-check`, which delegates to the existing `scripts/check-coverage.sh`
- Updated `check-coverage.sh` to also filter `/queries/` files from coverage, matching what CI was previously filtering
- Ensures local and CI coverage checks use the same code path

## Test plan
- [ ] Verify `make coverage-check` runs successfully locally
- [ ] Verify CI pipeline passes with the new step

🤖 Generated with [Claude Code](https://claude.com/claude-code)