### PR TITLE
chore(ci,docs): remove USE_POSTGRES env var references

### DIFF
--- a/scripts/ci/test-modes.sh
+++ b/scripts/ci/test-modes.sh
@@ -81,10 +81,7 @@ test_migrate_mode() {
     # Set DATABASE_URL with sslmode=disable for test environments
     export DATABASE_URL="postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/lampcontrol_prod?sslmode=disable"
 
-    # Enable PostgreSQL for applications that check this flag (TypeScript, Kotlin)
-    export USE_POSTGRES="true"
-
-    # Also set individual DB_* variables for applications that don't parse DATABASE_URL
+    # Set individual DB_* variables for applications that don't parse DATABASE_URL
     export DB_HOST="$POSTGRES_HOST"
     export DB_PORT="$POSTGRES_PORT"
     export DB_NAME="lampcontrol_prod"
@@ -131,10 +128,7 @@ test_serve_only_mode() {
     # Use existing database from migrate test with sslmode=disable
     export DATABASE_URL="postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/lampcontrol_prod?sslmode=disable"
 
-    # Enable PostgreSQL for applications that check this flag (TypeScript, Kotlin)
-    export USE_POSTGRES="true"
-
-    # Also set individual DB_* variables for applications that don't parse DATABASE_URL
+    # Set individual DB_* variables for applications that don't parse DATABASE_URL
     export DB_HOST="$POSTGRES_HOST"
     export DB_PORT="$POSTGRES_PORT"
     export DB_NAME="lampcontrol_prod"
@@ -226,10 +220,7 @@ test_serve_mode() {
     # Set DATABASE_URL with sslmode=disable for test environments
     export DATABASE_URL="postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/lampcontrol_serve?sslmode=disable"
 
-    # Enable PostgreSQL for applications that check this flag (TypeScript, Kotlin)
-    export USE_POSTGRES="true"
-
-    # Also set individual DB_* variables for applications that don't parse DATABASE_URL
+    # Set individual DB_* variables for applications that don't parse DATABASE_URL
     export DB_HOST="$POSTGRES_HOST"
     export DB_PORT="$POSTGRES_PORT"
     export DB_NAME="lampcontrol_serve"

--- a/src/typescript/README.md
+++ b/src/typescript/README.md
@@ -103,8 +103,6 @@ By default, the application uses an in-memory repository. This is suitable for d
 
 ```bash
 npm run dev
-# or
-USE_POSTGRES=false npm run dev
 ```
 
 ### PostgreSQL with Prisma ORM
@@ -127,7 +125,7 @@ For production deployments or when you need persistent storage:
 
 3. **Run the application with PostgreSQL:**
    ```bash
-   USE_POSTGRES=true npm run dev
+   DATABASE_URL="postgresql://lampuser:lamppass@localhost:5432/lampcontrol?schema=public" npm run dev
    ```
 
 4. **(Optional) Open Prisma Studio to view/edit data:**
@@ -147,9 +145,6 @@ DATABASE_URL="postgresql://lampuser:lamppass@localhost:5432/lampcontrol?schema=p
 # Application
 PORT=8080
 NODE_ENV=development
-
-# Storage Backend Selection
-USE_POSTGRES=true  # Set to 'true' to use PostgreSQL, 'false' or unset for in-memory
 ```
 
 ### Prisma Commands


### PR DESCRIPTION
## Summary
- remove USE_POSTGRES exports from CI mode tests
- update TypeScript README examples to rely on DATABASE_URL or default in-memory behavior
- keep runtime behavior unchanged (DATABASE_URL remains the switch for PostgreSQL)

## Validation
- rg -n "USE_POSTGRES" -S /Users/davide/.codex/worktrees/1d15/lamp-control-api-reference returned no matches
- bash -n /Users/davide/.codex/worktrees/1d15/lamp-control-api-reference/scripts/ci/test-modes.sh passed