### PR TITLE
docs(go): clarify DATABASE_URL accepts postgres and postgresql schemes

### DIFF
--- a/src/go/MIGRATIONS.md
+++ b/src/go/MIGRATIONS.md
@@ -123,7 +123,7 @@ A "dirty" migration means golang-migrate detected that a migration started but d
 
 ### Connection String Format
 
-golang-migrate requires PostgreSQL connection strings in URL format, using either `postgres://...` or `postgresql://...`:
+golang-migrate requires PostgreSQL connection strings in URL format. The `database/postgres` driver used by this service registers both `postgres://...` and `postgresql://...` schemes:
 ```
 postgres://user:password@host:port/database?sslmode=disable
 postgresql://user:password@host:port/database?sslmode=disable

--- a/src/go/README.md
+++ b/src/go/README.md
@@ -140,7 +140,10 @@ export DB_PASSWORD=lamp_password
 Using DATABASE_URL:
 ```bash
 # Development only - disables SSL. For production, use sslmode=require or sslmode=verify-full
+# Choose one of the following equivalent URL schemes:
+# Option 1: postgres scheme
 export DATABASE_URL="postgres://lamp_user:lamp_password@localhost:5432/lamp_control?sslmode=disable"
+# Option 2: postgresql scheme
 export DATABASE_URL="postgresql://lamp_user:lamp_password@localhost:5432/lamp_control?sslmode=disable"
 ```
 


### PR DESCRIPTION
## Summary
- document that DATABASE_URL supports both postgres://... and postgresql://...
- add both schemes to the README connection string examples
- update migration docs to describe both valid URL prefixes

## Validation
- verified README and MIGRATIONS mention both schemes consistently
- behavior matches pgxpool.ParseConfig usage in src/go/api/config.go