### PR TITLE
feat(java): support postgres URI forms for DATABASE_URL

### DIFF
--- a/src/java/README.md
+++ b/src/java/README.md
@@ -168,7 +168,11 @@ Configure database connection using environment variables to enable PostgreSQL m
 
 ```bash
 # Required to enable PostgreSQL mode
-export DATABASE_URL=jdbc:postgresql://localhost:5432/lampcontrol
+# Accepted formats: jdbc:postgresql://..., postgresql://..., postgres://...
+export DATABASE_URL=postgresql://localhost:5432/lampcontrol
+
+# Optional override (takes precedence and is used as-is without normalization)
+# export SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/lampcontrol
 
 # Database credentials
 export DB_USER=lampuser
@@ -200,7 +204,7 @@ spring.datasource.hikari.minimum-idle=5
 mvn spring-boot:run
 
 # Run with PostgreSQL (requires DATABASE_URL)
-DATABASE_URL=jdbc:postgresql://localhost:5432/lampcontrol \
+DATABASE_URL=postgresql://localhost:5432/lampcontrol \
 FLYWAY_ENABLED=true \
 DB_USER=lampuser \
 DB_PASSWORD=lamppass \

--- a/src/java/src/main/resources/application.properties
+++ b/src/java/src/main/resources/application.properties
@@ -6,7 +6,9 @@ spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS=false
 # Database Configuration (PostgreSQL)
 # By default, the application uses an in-memory repository
 # To enable PostgreSQL, set DATABASE_URL environment variable
-# Example: DATABASE_URL=jdbc:postgresql://localhost:5432/lampcontrol
+# DATABASE_URL supports: jdbc:postgresql://..., postgresql://..., postgres://...
+# SPRING_DATASOURCE_URL is used as-is when set (no normalization)
+# Example: DATABASE_URL=postgresql://localhost:5432/lampcontrol
 spring.datasource.url=${SPRING_DATASOURCE_URL:${DATABASE_URL:}}
 spring.datasource.username=${DB_USER:lampuser}
 spring.datasource.password=${DB_PASSWORD:lamppass}


### PR DESCRIPTION
## Summary
- add DATABASE_URL resolution logic in Java datasource config with explicit precedence
- keep SPRING_DATASOURCE_URL behavior unchanged (used as-is when set)
- normalize DATABASE_URL values for postgresql:// and postgres:// into JDBC URLs
- add unit tests covering precedence and normalization scenarios
- update Java application/docs examples for accepted DATABASE_URL formats

## Testing
- mvn -f src/java/pom.xml -Dtest=DataSourceConfigTest test (tests pass; build exits non-zero due to project-wide JaCoCo coverage gate when running only one class)
- mvn -f src/java/pom.xml test (fails in this environment due to pre-existing Mockito/ByteBuddy self-attach issue unrelated to this change)
