### PR TITLE
feat(kotlin): implement effective pagination for GET /v1/lamps

### DIFF
--- a/src/kotlin/src/main/kotlin/com/lampcontrol/api/apis/DefaultApi.kt
+++ b/src/kotlin/src/main/kotlin/com/lampcontrol/api/apis/DefaultApi.kt
@@ -53,13 +53,8 @@ fun Route.DefaultApi(lampService: LampService) {
             return@get
         }
 
-        val lamps = lampService.getAllLamps()
-        val response =
-            ListLamps200Response(
-                data = lamps,
-                hasMore = false,
-                nextCursor = null,
-            )
+        val normalizedPageSize = pageSize ?: 25
+        val response = lampService.getLampsPage(cursor = it.cursor, pageSize = normalizedPageSize)
         call.respond(HttpStatusCode.OK, response)
     }
 

--- a/src/kotlin/src/main/kotlin/com/lampcontrol/repository/LampRepository.kt
+++ b/src/kotlin/src/main/kotlin/com/lampcontrol/repository/LampRepository.kt
@@ -11,6 +11,11 @@ import java.util.UUID
 interface LampRepository {
     suspend fun getAllLamps(): List<LampEntity>
 
+    suspend fun getLampsPage(
+        offset: Int,
+        limit: Int,
+    ): List<LampEntity>
+
     suspend fun getLampById(id: UUID): LampEntity?
 
     suspend fun createLamp(entity: LampEntity): LampEntity

--- a/src/kotlin/src/main/kotlin/com/lampcontrol/repository/PostgresLampRepository.kt
+++ b/src/kotlin/src/main/kotlin/com/lampcontrol/repository/PostgresLampRepository.kt
@@ -27,6 +27,20 @@ class PostgresLampRepository : LampRepository {
                 .map { rowToEntity(it) }
         }
 
+    override suspend fun getLampsPage(
+        offset: Int,
+        limit: Int,
+    ): List<LampEntity> =
+        dbQuery {
+            LampsTable
+                .selectAll()
+                .where { LampsTable.deletedAt.isNull() }
+                .orderBy(LampsTable.createdAt to SortOrder.ASC, LampsTable.id to SortOrder.ASC)
+                .limit(limit)
+                .offset(offset.toLong())
+                .map { rowToEntity(it) }
+        }
+
     override suspend fun getLampById(id: UUID): LampEntity? =
         dbQuery {
             LampsTable

--- a/src/kotlin/src/main/kotlin/com/lampcontrol/service/InMemoryLampRepository.kt
+++ b/src/kotlin/src/main/kotlin/com/lampcontrol/service/InMemoryLampRepository.kt
@@ -20,6 +20,20 @@ class InMemoryLampRepository : LampRepository {
         return lamps.values.toList()
     }
 
+    override suspend fun getLampsPage(
+        offset: Int,
+        limit: Int,
+    ): List<LampEntity> {
+        val ordered =
+            lamps.values.sortedWith(
+                compareBy<LampEntity>({ it.createdAt }, { it.id }),
+            )
+        val start = offset.coerceAtLeast(0)
+        if (start >= ordered.size) return emptyList()
+        val end = (start + limit).coerceAtMost(ordered.size)
+        return ordered.subList(start, end)
+    }
+
     /**
      * Get a lamp by ID
      */


### PR DESCRIPTION
## Summary
- implement bounded cursor/pageSize pagination for Kotlin `GET /v1/lamps`
- add repository-level paged retrieval for in-memory and PostgreSQL modes
- return meaningful `hasMore` and `nextCursor` using `pageSize + 1` sentinel logic

## Details
- route now validates/defaults `pageSize` and delegates pagination to service
- service parses numeric cursor (invalid/negative fallback to `0`) and computes pagination metadata
- Postgres repository now applies `deleted_at IS NULL`, deterministic ordering (`created_at`, `id`), `LIMIT`, and `OFFSET`
- in-memory repository now applies equivalent deterministic ordering and bounded slicing

## Tests
- added API pagination flow coverage in `ApplicationTest`
- added service pagination and cursor-fallback tests in `LampServiceTest`
- added in-memory repository paging tests
- added postgres repository paging test (requires Docker/Testcontainers)

Closes #373
