### PR TITLE
fix(pre-commit): remove SQL hook and fix Go hook array handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,10 +42,3 @@ repos:
         language: system
         pass_filenames: true
         files: ^src/kotlin/.*\.(kt|kts)$
-
-      - id: sql-format-lint
-        name: SQL format and lint
-        entry: scripts/hooks/sql.sh
-        language: system
-        pass_filenames: true
-        files: ^database/sql/postgresql/.*\.sql$

--- a/scripts/hooks/go.sh
+++ b/scripts/hooks/go.sh
@@ -40,12 +40,14 @@ for file in "${go_files[@]}"; do
   fi
 
   exists=0
-  for existing in "${go_pkgs[@]}"; do
-    if [[ "$existing" == "$pkg" ]]; then
-      exists=1
-      break
-    fi
-  done
+  if [[ ${#go_pkgs[@]} -gt 0 ]]; then
+    for existing in "${go_pkgs[@]}"; do
+      if [[ "$existing" == "$pkg" ]]; then
+        exists=1
+        break
+      fi
+    done
+  fi
   if [[ $exists -eq 0 ]]; then
     go_pkgs+=("$pkg")
   fi


### PR DESCRIPTION
## Summary
- remove `sql-format-lint` from pre-commit configuration
- fix `scripts/hooks/go.sh` to handle an empty `go_pkgs` array safely under `set -u`

## Notes
- this PR intentionally includes only pre-commit hook maintenance changes
- existing unrelated working tree changes were left untouched