### PR TITLE
fix(kotlin): support Cloud SQL socket DATABASE_URL parsing

### DIFF
--- a/src/kotlin/build.gradle.kts
+++ b/src/kotlin/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
     implementation("org.jetbrains.exposed:exposed-jdbc:0.55.0")
     implementation("org.jetbrains.exposed:exposed-java-time:0.55.0")
     implementation("org.postgresql:postgresql:42.7.4")
+    implementation("com.google.cloud.sql:postgres-socket-factory:1.28.0")
     implementation("com.zaxxer:HikariCP:5.1.0")
 
     // Flyway for database migrations

--- a/src/kotlin/src/test/kotlin/com/lampcontrol/database/DatabaseConfigEnvironmentVariableTest.kt
+++ b/src/kotlin/src/test/kotlin/com/lampcontrol/database/DatabaseConfigEnvironmentVariableTest.kt
@@ -242,7 +242,23 @@ class DatabaseConfigEnvironmentVariableTest {
         assertEquals(5432, config.port)
         assertEquals("lamp-control", config.database)
         assertEquals(
-            "jdbc:postgresql:///lamp-control?host=/cloudsql/lamp-control-469416:europe-west1:lamp-control-db&connect_timeout=5",
+            "jdbc:postgresql://localhost/lamp-control?host=/cloudsql/lamp-control-469416:europe-west1:lamp-control-db&connect_timeout=5",
+            config.connectionString(),
+        )
+    }
+
+    @Test
+    @SetEnvironmentVariable(
+        key = "DATABASE_URL",
+        value = "postgresql://postgres:secret@/lamp-control?unixSocketPath=/cloudsql/project:region:instance",
+    )
+    fun `fromEnv parses unixSocketPath query parameter`() {
+        val config = DatabaseConfig.fromEnv()
+
+        assertNotNull(config)
+        assertEquals("/cloudsql/project:region:instance", config.host)
+        assertEquals(
+            "jdbc:postgresql://localhost/lamp-control?unixSocketPath=/cloudsql/project:region:instance",
             config.connectionString(),
         )
     }


### PR DESCRIPTION
## Summary
- update Kotlin DatabaseConfig URL parsing to support Cloud SQL Unix socket style URLs (host in query string)
- decode percent-encoded credentials from DATABASE_URL
- preserve query parameters in generated JDBC URL for socket/query options
- add regression tests for Cloud SQL socket URL parsing and encoded password decoding

## Testing
- ./gradlew test --tests com.lampcontrol.database.DatabaseConfigEnvironmentVariableTest --tests com.lampcontrol.database.DatabaseConfigTest --tests com.lampcontrol.database.DatabaseConfigEnvironmentTest -x jacocoTestCoverageVerification