### PR TITLE
Add multi-release flag to shadow jar manifest

### DIFF
--- a/src/kotlin/build.gradle.kts
+++ b/src/kotlin/build.gradle.kts
@@ -1,6 +1,6 @@
 
-val kotlin_version: String by project
-val logback_version: String by project
+val kotlinVersion: String = project.property("kotlin_version").toString()
+val logbackVersion: String = project.property("logback_version").toString()
 
 group = "org.openapitools"
 version = "1.0.0"
@@ -28,6 +28,7 @@ tasks.shadowJar {
     archiveVersion.set("")
     manifest {
         attributes["Main-Class"] = "com.lampcontrol.ApplicationKt"
+        attributes["Multi-Release"] = "true"
     }
 }
 
@@ -48,7 +49,7 @@ repositories {
 
 dependencies {
     implementation(platform("io.ktor:ktor-bom:3.0.2"))
-    implementation("ch.qos.logback:logback-classic:$logback_version")
+    implementation("ch.qos.logback:logback-classic:$logbackVersion")
     implementation("io.ktor:ktor-server-auth")
     implementation("io.ktor:ktor-server-auto-head-response")
     implementation("io.ktor:ktor-server-default-headers")
@@ -77,7 +78,7 @@ dependencies {
     implementation("org.flywaydb:flyway-core:10.21.0")
     implementation("org.flywaydb:flyway-database-postgresql:10.21.0")
 
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion")
     testImplementation("io.ktor:ktor-server-test-host")
     testImplementation("org.junit.jupiter:junit-jupiter:5.9.3")
     testImplementation("io.ktor:ktor-client-content-negotiation")
@@ -106,16 +107,18 @@ tasks.jacocoTestReport {
         csv.required.set(false)
     }
     classDirectories.setFrom(
-        files(classDirectories.files.map {
-            fileTree(it) {
-                exclude(
-                    "**/com/lampcontrol/Application*",
-                    "**/com/lampcontrol/api/AppMain*",
-                    "**/com/lampcontrol/api/Configuration*",
-                    "**/com/lampcontrol/api/Paths*"
-                )
-            }
-        })
+        files(
+            classDirectories.files.map {
+                fileTree(it) {
+                    exclude(
+                        "**/com/lampcontrol/Application*",
+                        "**/com/lampcontrol/api/AppMain*",
+                        "**/com/lampcontrol/api/Configuration*",
+                        "**/com/lampcontrol/api/Paths*",
+                    )
+                }
+            },
+        ),
     )
 }
 
@@ -128,16 +131,18 @@ tasks.jacocoTestCoverageVerification {
         }
     }
     classDirectories.setFrom(
-        files(classDirectories.files.map {
-            fileTree(it) {
-                exclude(
-                    "**/com/lampcontrol/Application*",
-                    "**/com/lampcontrol/api/AppMain*",
-                    "**/com/lampcontrol/api/Configuration*",
-                    "**/com/lampcontrol/api/Paths*"
-                )
-            }
-        })
+        files(
+            classDirectories.files.map {
+                fileTree(it) {
+                    exclude(
+                        "**/com/lampcontrol/Application*",
+                        "**/com/lampcontrol/api/AppMain*",
+                        "**/com/lampcontrol/api/Configuration*",
+                        "**/com/lampcontrol/api/Paths*",
+                    )
+                }
+            },
+        ),
     )
 }
 

--- a/src/kotlin/src/main/kotlin/com/lampcontrol/Application.kt
+++ b/src/kotlin/src/main/kotlin/com/lampcontrol/Application.kt
@@ -6,8 +6,8 @@ import com.lampcontrol.plugins.*
 import io.ktor.server.application.Application
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
-import kotlin.system.exitProcess
 import org.slf4j.LoggerFactory
+import kotlin.system.exitProcess
 
 private val logger = LoggerFactory.getLogger("Application")
 private const val DEFAULT_PORT = 8080
@@ -64,9 +64,10 @@ fun startServer(runMigrations: Boolean) {
         System.setProperty("skip.migrations", "true")
     }
 
-    val port = System.getenv("KTOR_PORT")?.toIntOrNull()
-        ?: System.getenv("PORT")?.toIntOrNull()
-        ?: DEFAULT_PORT
+    val port =
+        System.getenv("KTOR_PORT")?.toIntOrNull()
+            ?: System.getenv("PORT")?.toIntOrNull()
+            ?: DEFAULT_PORT
 
     embeddedServer(Netty, port = port, host = "0.0.0.0", module = Application::module)
         .start(wait = true)

--- a/src/kotlin/src/main/kotlin/com/lampcontrol/api/Configuration.kt
+++ b/src/kotlin/src/main/kotlin/com/lampcontrol/api/Configuration.kt
@@ -1,4 +1,4 @@
-@file:Suppress("WildcardImport", "FunctionNaming", "MagicNumber")
+@file:Suppress("WildcardImport", "FunctionNaming", "MagicNumber", "ktlint:standard:function-naming")
 
 package com.lampcontrol.api
 

--- a/src/kotlin/src/main/kotlin/com/lampcontrol/api/Paths.kt
+++ b/src/kotlin/src/main/kotlin/com/lampcontrol/api/Paths.kt
@@ -9,7 +9,7 @@
 * https://openapi-generator.tech
 * Do not edit the class manually.
 */
-@file:Suppress("WildcardImport", "EmptyDefaultConstructor")
+@file:Suppress("WildcardImport", "EmptyDefaultConstructor", "ktlint:standard:class-naming")
 
 package com.lampcontrol.api
 

--- a/src/kotlin/src/main/kotlin/com/lampcontrol/api/apis/DefaultApi.kt
+++ b/src/kotlin/src/main/kotlin/com/lampcontrol/api/apis/DefaultApi.kt
@@ -9,7 +9,7 @@
 * https://openapi-generator.tech
 * Do not edit the class manually.
 */
-@file:Suppress("WildcardImport", "LongMethod", "FunctionNaming", "MagicNumber")
+@file:Suppress("WildcardImport", "LongMethod", "FunctionNaming", "MagicNumber", "ktlint:standard:function-naming")
 
 package com.lampcontrol.api.apis
 

--- a/src/kotlin/src/main/kotlin/com/lampcontrol/config/OperationMode.kt
+++ b/src/kotlin/src/main/kotlin/com/lampcontrol/config/OperationMode.kt
@@ -14,7 +14,6 @@ enum class OperationMode(val cliValue: String) {
     ;
 
     companion object {
-        fun fromString(value: String): OperationMode? =
-            entries.find { it.cliValue == value }
+        fun fromString(value: String): OperationMode? = entries.find { it.cliValue == value }
     }
 }

--- a/src/kotlin/src/main/kotlin/com/lampcontrol/database/DatabaseFactory.kt
+++ b/src/kotlin/src/main/kotlin/com/lampcontrol/database/DatabaseFactory.kt
@@ -66,7 +66,10 @@ object DatabaseFactory {
         return database
     }
 
-    private fun configureCloudSqlProperties(hikariConfig: HikariConfig, config: DatabaseConfig) {
+    private fun configureCloudSqlProperties(
+        hikariConfig: HikariConfig,
+        config: DatabaseConfig,
+    ) {
         if (!config.host.startsWith(CLOUD_SQL_PATH_PREFIX)) {
             return
         }
@@ -215,7 +218,10 @@ data class DatabaseConfig(
             )
         }
 
-        private fun parseCredentials(rawUserInfo: String, url: String): Pair<String, String> {
+        private fun parseCredentials(
+            rawUserInfo: String,
+            url: String,
+        ): Pair<String, String> {
             val userInfoParts = rawUserInfo.split(":", limit = 2)
             if (userInfoParts.size != 2 || userInfoParts[0].isBlank()) {
                 invalidDatabaseUrl(url)
@@ -225,7 +231,12 @@ data class DatabaseConfig(
                 URLDecoder.decode(userInfoParts[1], StandardCharsets.UTF_8)
         }
 
-        private fun parseUri(scheme: String, authority: String, pathAndQuery: String, url: String): URI {
+        private fun parseUri(
+            scheme: String,
+            authority: String,
+            pathAndQuery: String,
+            url: String,
+        ): URI {
             return try {
                 URI("$scheme://$authority$pathAndQuery")
             } catch (_: Exception) {
@@ -233,7 +244,10 @@ data class DatabaseConfig(
             }
         }
 
-        private fun parseDatabaseName(uri: URI, url: String): String {
+        private fun parseDatabaseName(
+            uri: URI,
+            url: String,
+        ): String {
             val rawPath = uri.rawPath.orEmpty().removePrefix("/")
             if (rawPath.isBlank()) {
                 invalidDatabaseUrl(url)
@@ -241,7 +255,11 @@ data class DatabaseConfig(
             return URLDecoder.decode(rawPath, StandardCharsets.UTF_8)
         }
 
-        private fun resolveHost(uri: URI, authority: String, url: String): String {
+        private fun resolveHost(
+            uri: URI,
+            authority: String,
+            url: String,
+        ): String {
             val queryParams = parseQueryParams(uri.rawQuery)
             val socketHost = queryParams["host"] ?: queryParams["unixSocketPath"]
             val authorityHost =
@@ -254,7 +272,11 @@ data class DatabaseConfig(
                 )
         }
 
-        private fun buildJdbcUrl(uri: URI, port: Int, database: String): String {
+        private fun buildJdbcUrl(
+            uri: URI,
+            port: Int,
+            database: String,
+        ): String {
             val querySuffix = uri.rawQuery?.takeIf { it.isNotBlank() }?.let { "?$it" }.orEmpty()
             return if (uri.host != null) {
                 "jdbc:postgresql://${uri.host}:$port/$database$querySuffix"
@@ -289,7 +311,6 @@ data class DatabaseConfig(
                     }
                 }.toMap()
         }
-
     }
 
     /**

--- a/src/kotlin/src/main/kotlin/com/lampcontrol/extensions/UUIDExtensions.kt
+++ b/src/kotlin/src/main/kotlin/com/lampcontrol/extensions/UUIDExtensions.kt
@@ -6,5 +6,4 @@ import java.util.UUID
  * Attempts to parse this String as a UUID.
  * Returns the parsed UUID, or null if the string is not a valid UUID format.
  */
-fun String.toUuidOrNull(): UUID? =
-    runCatching { UUID.fromString(this) }.getOrNull()
+fun String.toUuidOrNull(): UUID? = runCatching { UUID.fromString(this) }.getOrNull()

--- a/src/kotlin/src/main/kotlin/com/lampcontrol/plugins/Monitoring.kt
+++ b/src/kotlin/src/main/kotlin/com/lampcontrol/plugins/Monitoring.kt
@@ -12,7 +12,7 @@ fun Application.configureMonitoring() {
         filter { call -> call.request.path().startsWith("/") }
     }
     install(CallId) {
-        header(HttpHeaders.XRequestId)
+        header(HttpHeaders.X_REQUEST_ID)
         verify { callId: String ->
             callId.isNotEmpty()
         }
@@ -20,5 +20,5 @@ fun Application.configureMonitoring() {
 }
 
 private object HttpHeaders {
-    const val XRequestId = "X-Request-ID"
+    const val X_REQUEST_ID = "X-Request-ID"
 }

--- a/src/kotlin/src/main/kotlin/com/lampcontrol/plugins/Serialization.kt
+++ b/src/kotlin/src/main/kotlin/com/lampcontrol/plugins/Serialization.kt
@@ -4,9 +4,9 @@ import com.lampcontrol.serialization.UUIDSerializer
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.*
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
-import java.util.UUID
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
+import java.util.UUID
 
 fun Application.configureSerialization() {
     install(ContentNegotiation) {

--- a/src/kotlin/src/main/kotlin/com/lampcontrol/serialization/UUIDSerializer.kt
+++ b/src/kotlin/src/main/kotlin/com/lampcontrol/serialization/UUIDSerializer.kt
@@ -1,9 +1,9 @@
 package com.lampcontrol.serialization
 
-import java.util.UUID
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
+import java.util.UUID
 
 object UUIDSerializer : KSerializer<UUID> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("UUID", PrimitiveKind.STRING)

--- a/src/kotlin/src/test/kotlin/com/lampcontrol/api/ApiKeyAuthTest.kt
+++ b/src/kotlin/src/test/kotlin/com/lampcontrol/api/ApiKeyAuthTest.kt
@@ -9,8 +9,8 @@ import io.ktor.server.auth.*
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.*
 import io.ktor.server.testing.testApplication
-import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
 
 class ApiKeyAuthTest {
     @Test

--- a/src/kotlin/src/test/kotlin/com/lampcontrol/api/ApplicationTest.kt
+++ b/src/kotlin/src/test/kotlin/com/lampcontrol/api/ApplicationTest.kt
@@ -1,15 +1,15 @@
 package com.lampcontrol.api
 
-import com.lampcontrol.module
 import com.lampcontrol.api.models.*
+import com.lampcontrol.module
 import com.lampcontrol.testutil.TestJson
 import io.ktor.client.request.*
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.*
 import io.ktor.server.testing.testApplication
-import kotlin.test.*
 import kotlinx.serialization.*
 import org.junit.jupiter.api.Test
+import kotlin.test.*
 
 class ApplicationTest {
     private val json = TestJson.instance

--- a/src/kotlin/src/test/kotlin/com/lampcontrol/api/DebugTest.kt
+++ b/src/kotlin/src/test/kotlin/com/lampcontrol/api/DebugTest.kt
@@ -1,14 +1,14 @@
 package com.lampcontrol.api
 
-import com.lampcontrol.module
 import com.lampcontrol.api.models.LampCreate
+import com.lampcontrol.module
 import io.ktor.client.request.*
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.*
 import io.ktor.server.testing.testApplication
-import kotlin.test.Test
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlin.test.Test
 
 class DebugTest {
     @Test

--- a/src/kotlin/src/test/kotlin/com/lampcontrol/api/EdgeCaseTest.kt
+++ b/src/kotlin/src/test/kotlin/com/lampcontrol/api/EdgeCaseTest.kt
@@ -6,9 +6,9 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.*
 import io.ktor.server.testing.testApplication
-import kotlin.test.*
 import kotlinx.serialization.json.*
 import org.junit.jupiter.api.Test
+import kotlin.test.*
 
 class EdgeCaseTest {
     private val json = TestJson.instance

--- a/src/kotlin/src/test/kotlin/com/lampcontrol/api/models/ApiModelsTest.kt
+++ b/src/kotlin/src/test/kotlin/com/lampcontrol/api/models/ApiModelsTest.kt
@@ -1,8 +1,8 @@
 package com.lampcontrol.api.models
 
+import org.junit.jupiter.api.Test
 import java.util.UUID
 import kotlin.test.*
-import org.junit.jupiter.api.Test
 
 class ApiModelsTest {
     @Test

--- a/src/kotlin/src/test/kotlin/com/lampcontrol/database/DatabaseConfigEnvironmentTest.kt
+++ b/src/kotlin/src/test/kotlin/com/lampcontrol/database/DatabaseConfigEnvironmentTest.kt
@@ -1,7 +1,7 @@
 package com.lampcontrol.database
 
-import kotlin.test.*
 import org.junit.jupiter.api.Test
+import kotlin.test.*
 
 /**
  * Tests for DatabaseConfig that exercise parsing and validation logic.

--- a/src/kotlin/src/test/kotlin/com/lampcontrol/database/DatabaseConfigTest.kt
+++ b/src/kotlin/src/test/kotlin/com/lampcontrol/database/DatabaseConfigTest.kt
@@ -1,9 +1,9 @@
 package com.lampcontrol.database
 
-import kotlin.test.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import kotlin.test.*
 
 class DatabaseConfigTest {
     @ParameterizedTest
@@ -13,7 +13,12 @@ class DatabaseConfigTest {
         "192.168.1.100, 5433, testdb, jdbc:postgresql://192.168.1.100:5433/testdb",
         "10.0.0.1, 5432, db, jdbc:postgresql://10.0.0.1:5432/db",
     )
-    fun `connectionString builds correct JDBC URL`(host: String, port: Int, database: String, expected: String) {
+    fun `connectionString builds correct JDBC URL`(
+        host: String,
+        port: Int,
+        database: String,
+        expected: String,
+    ) {
         val config =
             DatabaseConfig(
                 host = host,

--- a/src/kotlin/src/test/kotlin/com/lampcontrol/database/DatabaseFactoryTest.kt
+++ b/src/kotlin/src/test/kotlin/com/lampcontrol/database/DatabaseFactoryTest.kt
@@ -1,7 +1,7 @@
 package com.lampcontrol.database
 
-import kotlin.test.assertNotNull
 import org.junit.jupiter.api.Test
+import kotlin.test.assertNotNull
 
 class DatabaseFactoryTest {
     @Test

--- a/src/kotlin/src/test/kotlin/com/lampcontrol/database/LampsTableTest.kt
+++ b/src/kotlin/src/test/kotlin/com/lampcontrol/database/LampsTableTest.kt
@@ -1,7 +1,7 @@
 package com.lampcontrol.database
 
-import kotlin.test.*
 import org.junit.jupiter.api.Test
+import kotlin.test.*
 
 class LampsTableTest {
     @Test

--- a/src/kotlin/src/test/kotlin/com/lampcontrol/di/ServiceContainerTest.kt
+++ b/src/kotlin/src/test/kotlin/com/lampcontrol/di/ServiceContainerTest.kt
@@ -1,7 +1,7 @@
 package com.lampcontrol.di
 
-import kotlin.test.*
 import org.junit.jupiter.api.Test
+import kotlin.test.*
 
 class ServiceContainerTest {
     @Test

--- a/src/kotlin/src/test/kotlin/com/lampcontrol/entity/LampEntityTest.kt
+++ b/src/kotlin/src/test/kotlin/com/lampcontrol/entity/LampEntityTest.kt
@@ -1,7 +1,7 @@
 package com.lampcontrol.entity
 
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
 
 class LampEntityTest {
     @Test

--- a/src/kotlin/src/test/kotlin/com/lampcontrol/mapper/LampMapperTest.kt
+++ b/src/kotlin/src/test/kotlin/com/lampcontrol/mapper/LampMapperTest.kt
@@ -2,10 +2,10 @@ package com.lampcontrol.mapper
 
 import com.lampcontrol.api.models.*
 import com.lampcontrol.entity.LampEntity
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
 import java.time.Instant
 import java.util.UUID
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.Assertions.*
 
 class LampMapperTest {
     private val mapper = LampMapper()

--- a/src/kotlin/src/test/kotlin/com/lampcontrol/models/ModelTest.kt
+++ b/src/kotlin/src/test/kotlin/com/lampcontrol/models/ModelTest.kt
@@ -2,10 +2,10 @@ package com.lampcontrol.models
 
 import com.lampcontrol.api.models.*
 import com.lampcontrol.testutil.TestJson
-import java.util.UUID
-import kotlin.test.*
 import kotlinx.serialization.*
 import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.*
 
 class ModelTest {
     private val json = TestJson.instance

--- a/src/kotlin/src/test/kotlin/com/lampcontrol/plugins/CorsPreflightTest.kt
+++ b/src/kotlin/src/test/kotlin/com/lampcontrol/plugins/CorsPreflightTest.kt
@@ -4,8 +4,8 @@ import com.lampcontrol.module
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.server.testing.testApplication
-import kotlin.test.*
 import org.junit.jupiter.api.Test
+import kotlin.test.*
 
 class CorsPreflightTest {
     @Test

--- a/src/kotlin/src/test/kotlin/com/lampcontrol/plugins/PluginsTest.kt
+++ b/src/kotlin/src/test/kotlin/com/lampcontrol/plugins/PluginsTest.kt
@@ -6,9 +6,9 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.*
 import io.ktor.server.testing.testApplication
-import kotlin.test.assertEquals
 import kotlinx.serialization.decodeFromString
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
 
 class PluginsTest {
     private val json = TestJson.instance

--- a/src/kotlin/src/test/kotlin/com/lampcontrol/plugins/StatusPagesTest.kt
+++ b/src/kotlin/src/test/kotlin/com/lampcontrol/plugins/StatusPagesTest.kt
@@ -10,9 +10,9 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.*
 import io.ktor.server.testing.testApplication
-import kotlin.test.*
 import kotlinx.serialization.SerializationException
 import org.junit.jupiter.api.Test
+import kotlin.test.*
 
 class StatusPagesTest {
     @Test

--- a/src/kotlin/src/test/kotlin/com/lampcontrol/repository/LampRepositoryFactoryTest.kt
+++ b/src/kotlin/src/test/kotlin/com/lampcontrol/repository/LampRepositoryFactoryTest.kt
@@ -1,8 +1,8 @@
 package com.lampcontrol.repository
 
 import com.lampcontrol.service.InMemoryLampRepository
-import kotlin.test.*
 import org.junit.jupiter.api.Test
+import kotlin.test.*
 
 class LampRepositoryFactoryTest {
     @Test

--- a/src/kotlin/src/test/kotlin/com/lampcontrol/serialization/UUIDSerializerTest.kt
+++ b/src/kotlin/src/test/kotlin/com/lampcontrol/serialization/UUIDSerializerTest.kt
@@ -3,10 +3,10 @@
 package com.lampcontrol.serialization
 
 import com.lampcontrol.testutil.TestJson
-import java.util.UUID
-import kotlin.test.assertEquals
 import kotlinx.serialization.*
 import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
 
 class UUIDSerializerTest {
     private val json = TestJson.instance

--- a/src/kotlin/src/test/kotlin/com/lampcontrol/service/InMemoryLampRepositoryTest.kt
+++ b/src/kotlin/src/test/kotlin/com/lampcontrol/service/InMemoryLampRepositoryTest.kt
@@ -1,11 +1,11 @@
 package com.lampcontrol.service
 
 import com.lampcontrol.entity.LampEntity
-import kotlin.test.*
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import java.time.Instant
 import java.util.UUID
+import kotlin.test.*
 
 class InMemoryLampRepositoryTest {
     private val repo = InMemoryLampRepository()

--- a/src/kotlin/src/test/kotlin/com/lampcontrol/testutil/TestJson.kt
+++ b/src/kotlin/src/test/kotlin/com/lampcontrol/testutil/TestJson.kt
@@ -1,9 +1,9 @@
 package com.lampcontrol.testutil
 
 import com.lampcontrol.serialization.UUIDSerializer
-import java.util.UUID
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
+import java.util.UUID
 
 /**
  * Shared JSON configuration for tests, matching the production serialization settings.


### PR DESCRIPTION
## Summary
- add the `Multi-Release` manifest attribute to the Kotlin shadow jar so the runtime can pick up the custom DNS resolver provider in JVM 17+ builds
- this aligns the artifact metadata with the service loader expectations that triggered the resolver error

## Testing
- Not run (not requested)