### PR TITLE
fix(benchmarks): replace uuid_generate_v5 with gen_random_uuid

### DIFF
--- a/benchmarks/k6/README.md
+++ b/benchmarks/k6/README.md
@@ -47,7 +47,7 @@ Edit `benchmarks/k6/services.json`:
 Default seeding is configured once in `benchmarks/k6/config.json` as `defaultDbSeedCommand`:
 
 ```bash
-psql "$BENCHMARK_DATABASE_URL" -v ON_ERROR_STOP=1 -c "TRUNCATE TABLE lamps RESTART IDENTITY CASCADE; INSERT INTO lamps (id, is_on, created_at, updated_at, deleted_at) SELECT uuid_generate_v5('6ba7b810-9dad-11d1-80b4-00c04fd430c8', 'lamp-' || g), (g % 2 = 0), NOW() - ((10001 - g) * INTERVAL '1 second'), NOW() - ((10001 - g) * INTERVAL '1 second'), NULL FROM generate_series(1, 10000) AS g;"
+psql "$BENCHMARK_DATABASE_URL" -v ON_ERROR_STOP=1 -c "TRUNCATE TABLE lamps RESTART IDENTITY CASCADE; INSERT INTO lamps (id, is_on, created_at, updated_at, deleted_at) SELECT gen_random_uuid(), (g % 2 = 0), NOW() - ((10001 - g) * INTERVAL '1 second'), NOW() - ((10001 - g) * INTERVAL '1 second'), NULL FROM generate_series(1, 10000) AS g;"
 ```
 
 Set `dbSeedCommand` in a service entry only when that service needs a custom seed/reset flow.

--- a/benchmarks/k6/config.fast.json
+++ b/benchmarks/k6/config.fast.json
@@ -51,7 +51,7 @@
     "seedFetchPages": 10,
     "seedPageSize": 100
   },
-  "defaultDbSeedCommand": "psql \"$BENCHMARK_DATABASE_URL\" -v ON_ERROR_STOP=1 -c \"TRUNCATE TABLE lamps RESTART IDENTITY CASCADE; INSERT INTO lamps (id, is_on, created_at, updated_at, deleted_at) SELECT uuid_generate_v5('6ba7b810-9dad-11d1-80b4-00c04fd430c8', 'lamp-' || g), (g % 2 = 0), NOW() - ((10001 - g) * INTERVAL '1 second'), NOW() - ((10001 - g) * INTERVAL '1 second'), NULL FROM generate_series(1, 10000) AS g;\"",
+  "defaultDbSeedCommand": "psql \"$BENCHMARK_DATABASE_URL\" -v ON_ERROR_STOP=1 -c \"TRUNCATE TABLE lamps RESTART IDENTITY CASCADE; INSERT INTO lamps (id, is_on, created_at, updated_at, deleted_at) SELECT gen_random_uuid(), (g % 2 = 0), NOW() - ((10001 - g) * INTERVAL '1 second'), NOW() - ((10001 - g) * INTERVAL '1 second'), NULL FROM generate_series(1, 10000) AS g;\"",
   "cloudRun": {
     "projectId": "lamp-control-469416",
     "projectNumber": "827868544165",

--- a/benchmarks/k6/config.json
+++ b/benchmarks/k6/config.json
@@ -44,7 +44,7 @@
     "seedFetchPages": 10,
     "seedPageSize": 100
   },
-  "defaultDbSeedCommand": "psql \"$BENCHMARK_DATABASE_URL\" -v ON_ERROR_STOP=1 -c \"TRUNCATE TABLE lamps RESTART IDENTITY CASCADE; INSERT INTO lamps (id, is_on, created_at, updated_at, deleted_at) SELECT uuid_generate_v5('6ba7b810-9dad-11d1-80b4-00c04fd430c8', 'lamp-' || g), (g % 2 = 0), NOW() - ((10001 - g) * INTERVAL '1 second'), NOW() - ((10001 - g) * INTERVAL '1 second'), NULL FROM generate_series(1, 10000) AS g;\"",
+  "defaultDbSeedCommand": "psql \"$BENCHMARK_DATABASE_URL\" -v ON_ERROR_STOP=1 -c \"TRUNCATE TABLE lamps RESTART IDENTITY CASCADE; INSERT INTO lamps (id, is_on, created_at, updated_at, deleted_at) SELECT gen_random_uuid(), (g % 2 = 0), NOW() - ((10001 - g) * INTERVAL '1 second'), NOW() - ((10001 - g) * INTERVAL '1 second'), NULL FROM generate_series(1, 10000) AS g;\"",
   "cloudRun": {
     "projectId": "lamp-control-469416",
     "projectNumber": "827868544165",


### PR DESCRIPTION
Replace `uuid_generate_v5` with `gen_random_uuid` in benchmark seed commands across configuration files.

**Changes:**
- Updated `benchmarks/k6/README.md` with the new UUID generation function
- Updated `benchmarks/k6/config.json` seed command
- Updated `benchmarks/k6/config.fast.json` seed command

This change simplifies UUID generation for the lamp table seeding by using the built-in random UUID function instead of the deterministic v5 variant.