### PR TITLE
fix(python): commit transaction after creating lamp

### DIFF
--- a/src/python/src/openapi_server/repositories/postgres_lamp_repository.py
+++ b/src/python/src/openapi_server/repositories/postgres_lamp_repository.py
@@ -57,6 +57,7 @@ class PostgresLampRepository:
 
         self._session.add(db_lamp)
         await self._session.flush()
+        await self._session.commit()
         await self._session.refresh(db_lamp)
 
         return self._to_entity(db_lamp)


### PR DESCRIPTION
## Summary

- `PostgresLampRepository.create()` was calling `flush()` but never `commit()`, so the INSERT was sent within the open transaction but rolled back when the session closed at the end of the request
- Subsequent GET requests from a new session correctly returned 404 since the lamp was never persisted
- `update` and `delete` both had `commit()` — `create` was simply missing it

## Test plan

- [ ] POST /v1/lamps followed by GET /v1/lamps/{lampId} returns 200 (was 404)
- [ ] Benchmark precheck no longer fails with repeated 404s
- [ ] Existing unit/integration tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)