### PR TITLE
fix(python): commit read-only sessions to avoid spurious rollbacks

### DIFF
--- a/src/python/src/openapi_server/infrastructure/database/database.py
+++ b/src/python/src/openapi_server/infrastructure/database/database.py
@@ -76,4 +76,9 @@ class DatabaseManager:
                 pass
         """
         async with self.async_session_factory() as session:
-            yield session
+            try:
+                yield session
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise


### PR DESCRIPTION
## Summary

- Every `GET` request opened an implicit PostgreSQL transaction that was rolled back when the SQLAlchemy session closed (via `async with session_factory() as session` → `session.close()` → implicit rollback)
- During benchmarks this appeared as ~200/s rollbacks vs ~20/s commits, even though no data was corrupted
- Fix wraps the session `yield` in `try/commit/except/rollback` so read-only transactions are committed rather than rolled back

## How it works

| Operation | Before | After |
|---|---|---|
| `GET /v1/lamps` | rollback (no commit) | commit (read-only tx, no data change) |
| `GET /v1/lamps/{id}` | rollback (no commit) | commit (read-only tx, no data change) |
| `POST /v1/lamps` | commit (already done in repo) | commit (outer commit is no-op) |
| `PUT /v1/lamps/{id}` | commit (already done in repo) | commit (outer commit is no-op) |
| `DELETE /v1/lamps/{id}` | commit (already done in repo) | commit (outer commit is no-op) |

Note: the `create()` missing-commit bug was separately fixed in #407.

## Test plan

- [ ] Run existing Python test suite: `cd src/python && poetry run pytest`
- [ ] Run a benchmark and verify the rollback/commit ratio normalises

🤖 Generated with [Claude Code](https://claude.com/claude-code)