### PR TITLE
fix(python): remove requirements.txt and fix Cloud Run startup

### DIFF
--- a/src/python/Procfile
+++ b/src/python/Procfile
@@ -1,1 +1,1 @@
-web: uvicorn main:app --host 0.0.0.0 --port 8080
+web: python -m uvicorn main:app --host 0.0.0.0 --port 8080

--- a/src/python/Procfile
+++ b/src/python/Procfile
@@ -1,1 +1,0 @@
-web: python -m uvicorn main:app --host 0.0.0.0 --port 8080

--- a/src/python/pyproject.toml
+++ b/src/python/pyproject.toml
@@ -16,6 +16,9 @@ build-backend = "poetry.core.masonry.api"
 package-mode = true
 packages = [{include = "openapi_server", from = "src"}]
 
+[tool.poetry.scripts]
+start = "openapi_server.cli:main"
+
 [tool.poetry.dependencies]
 python = "^3.14"
 fastapi = "^0.115.12"


### PR DESCRIPTION
## Summary

- **Remove `requirements.txt`** — the buildpack uses it when present, ignoring `pyproject.toml`. Since the project has `poetry.lock` + `[tool.poetry]`, deleting it lets the buildpack auto-detect Poetry, fixing `ModuleNotFoundError: No module named 'opentelemetry'`
- **Add `[tool.poetry.scripts] start`** and **delete `Procfile`** — the buildpack's entrypoint resolution order checks `[tool.poetry.scripts]` for a `start` script before any other heuristic. `start = "openapi_server.cli:main"` maps directly to the existing CLI entry point (defaults to `serve-only` mode), so the buildpack runs `poetry run start` with no PATH or virtualenv issues

## Entrypoint resolution order (from docs)

1. `Procfile` / `GOOGLE_ENTRYPOINT` env var ← removed
2. ✅ **`[tool.poetry.scripts]` containing `start`** ← now used
3. Other defined scripts
4. Framework auto-detection (uvicorn, fastapi, gunicorn…)

## Test plan

- [ ] Verify Cloud Run build logs show Poetry buildpack + `poetry run start`
- [ ] Verify server starts in `serve-only` mode (no migration errors on cold start)
- [ ] Verify OpenTelemetry instrumentation loads correctly
- [ ] Verify all API endpoints respond as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)