### PR TITLE
feat: use Cloud Run Gen2 execution environment for all services

### DIFF
--- a/src/csharp/service.yaml
+++ b/src/csharp/service.yaml
@@ -9,6 +9,7 @@ spec:
     metadata:
       annotations:
         autoscaling.knative.dev/maxScale: '1'
+        run.googleapis.com/cloudsql-instances: lamp-control-469416:europe-west1:lamp-control-db
         run.googleapis.com/execution-environment: gen2
         run.googleapis.com/startup-cpu-boost: 'true'
         run.googleapis.com/container-dependencies: "{app:[collector]}"

--- a/src/csharp/service.yaml
+++ b/src/csharp/service.yaml
@@ -9,6 +9,7 @@ spec:
     metadata:
       annotations:
         autoscaling.knative.dev/maxScale: '1'
+        run.googleapis.com/execution-environment: gen2
         run.googleapis.com/startup-cpu-boost: 'true'
         run.googleapis.com/container-dependencies: "{app:[collector]}"
     spec:

--- a/src/go/service.yaml
+++ b/src/go/service.yaml
@@ -9,6 +9,7 @@ spec:
     metadata:
       annotations:
         autoscaling.knative.dev/maxScale: '1'
+        run.googleapis.com/cloudsql-instances: lamp-control-469416:europe-west1:lamp-control-db
         run.googleapis.com/execution-environment: gen2
         run.googleapis.com/startup-cpu-boost: 'true'
         run.googleapis.com/container-dependencies: "{app:[collector]}"

--- a/src/go/service.yaml
+++ b/src/go/service.yaml
@@ -9,6 +9,7 @@ spec:
     metadata:
       annotations:
         autoscaling.knative.dev/maxScale: '1'
+        run.googleapis.com/execution-environment: gen2
         run.googleapis.com/startup-cpu-boost: 'true'
         run.googleapis.com/container-dependencies: "{app:[collector]}"
     spec:

--- a/src/java/service.yaml
+++ b/src/java/service.yaml
@@ -9,6 +9,7 @@ spec:
     metadata:
       annotations:
         autoscaling.knative.dev/maxScale: '1'
+        run.googleapis.com/cloudsql-instances: lamp-control-469416:europe-west1:lamp-control-db
         run.googleapis.com/execution-environment: gen2
         run.googleapis.com/startup-cpu-boost: 'true'
         run.googleapis.com/container-dependencies: "{app:[collector]}"

--- a/src/java/service.yaml
+++ b/src/java/service.yaml
@@ -9,6 +9,7 @@ spec:
     metadata:
       annotations:
         autoscaling.knative.dev/maxScale: '1'
+        run.googleapis.com/execution-environment: gen2
         run.googleapis.com/startup-cpu-boost: 'true'
         run.googleapis.com/container-dependencies: "{app:[collector]}"
     spec:

--- a/src/kotlin/service.yaml
+++ b/src/kotlin/service.yaml
@@ -9,6 +9,7 @@ spec:
     metadata:
       annotations:
         autoscaling.knative.dev/maxScale: '1'
+        run.googleapis.com/cloudsql-instances: lamp-control-469416:europe-west1:lamp-control-db
         run.googleapis.com/execution-environment: gen2
         run.googleapis.com/startup-cpu-boost: 'true'
         run.googleapis.com/container-dependencies: "{app:[collector]}"

--- a/src/kotlin/service.yaml
+++ b/src/kotlin/service.yaml
@@ -9,6 +9,7 @@ spec:
     metadata:
       annotations:
         autoscaling.knative.dev/maxScale: '1'
+        run.googleapis.com/execution-environment: gen2
         run.googleapis.com/startup-cpu-boost: 'true'
         run.googleapis.com/container-dependencies: "{app:[collector]}"
     spec:

--- a/src/python/service.yaml
+++ b/src/python/service.yaml
@@ -9,6 +9,7 @@ spec:
     metadata:
       annotations:
         autoscaling.knative.dev/maxScale: '1'
+        run.googleapis.com/cloudsql-instances: lamp-control-469416:europe-west1:lamp-control-db
         run.googleapis.com/execution-environment: gen2
         run.googleapis.com/startup-cpu-boost: 'true'
         run.googleapis.com/container-dependencies: "{app:[collector]}"

--- a/src/python/service.yaml
+++ b/src/python/service.yaml
@@ -9,6 +9,7 @@ spec:
     metadata:
       annotations:
         autoscaling.knative.dev/maxScale: '1'
+        run.googleapis.com/execution-environment: gen2
         run.googleapis.com/startup-cpu-boost: 'true'
         run.googleapis.com/container-dependencies: "{app:[collector]}"
     spec:

--- a/src/typescript/service.yaml
+++ b/src/typescript/service.yaml
@@ -9,6 +9,7 @@ spec:
     metadata:
       annotations:
         autoscaling.knative.dev/maxScale: '1'
+        run.googleapis.com/cloudsql-instances: lamp-control-469416:europe-west1:lamp-control-db
         run.googleapis.com/execution-environment: gen2
         run.googleapis.com/startup-cpu-boost: 'true'
         run.googleapis.com/container-dependencies: "{app:[collector]}"

--- a/src/typescript/service.yaml
+++ b/src/typescript/service.yaml
@@ -9,6 +9,7 @@ spec:
     metadata:
       annotations:
         autoscaling.knative.dev/maxScale: '1'
+        run.googleapis.com/execution-environment: gen2
         run.googleapis.com/startup-cpu-boost: 'true'
         run.googleapis.com/container-dependencies: "{app:[collector]}"
     spec:


### PR DESCRIPTION
## Summary

- Adds `run.googleapis.com/execution-environment: gen2` annotation to all six `service.yaml` files (TypeScript, Python, Go, Java, Kotlin, C#)
- Explicitly opts in to the second generation Cloud Run execution environment, which provides better performance, full Linux compatibility, and is required for sidecar container support

## Test plan

- [ ] Deploy any updated service: `gcloud run services replace src/<lang>/service.yaml --region=<region>`
- [ ] Verify annotation: `gcloud run services describe <service-name> --region=<region> --format='get(spec.template.metadata.annotations)'` — should show `run.googleapis.com/execution-environment: gen2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)